### PR TITLE
Making the lookup table static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,23 +142,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "logos"
 version = "0.2.3"
 dependencies = [
- "logos-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logos-derive 0.2.3",
  "toolshed 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "logos-derive"
 version = "0.2.3"
-dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -408,7 +398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum logos-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc10c37b68a939e898b2a65a6c4b56afcc5391b8d2906e11cf3c558c717f3ff"
 "checksum luther 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06f4cea3d0eb2247968458e31546dd676406dd5b8ecab4fb09290a73de99c00c"
 "checksum luther-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64e6619260728020da3870d66e90492fe093674929670e0b19d4659bf3596c62"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,15 +140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "logos"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
- "logos-derive 0.2.3",
+ "logos-derive 0.3.0",
  "toolshed 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -321,8 +321,8 @@ dependencies = [
 name = "tests"
 version = "0.0.0"
 dependencies = [
- "logos 0.2.3",
- "logos-derive 0.2.3",
+ "logos 0.3.0",
+ "logos-derive 0.3.0",
  "luther 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "luther-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ fn main() {
 Ridiculously fast!
 
 ```
-test logos                ... bench:       2,086 ns/iter (+/- 73) = 1021 MB/s
-test logos_nul_terminated ... bench:       1,956 ns/iter (+/- 141) = 1089 MB/s
+test logos                ... bench:       2,005 ns/iter (+/- 16) = 1062 MB/s
+test logos_nul_terminated ... bench:       1,828 ns/iter (+/- 69) = 1165 MB/s
 ```
 
 ## TODOs

--- a/logos-derive/Cargo.toml
+++ b/logos-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logos-derive"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["maciejhirsz <maciej.hirsz@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Create ridiculously fast Lexers"

--- a/logos-derive/src/generator.rs
+++ b/logos-derive/src/generator.rs
@@ -45,10 +45,10 @@ impl<'a> Generator<'a> {
             None => {
                 let body = self.tree_to_fn_body(tree);
 
-                quote!(Some(|lex| {
+                quote!(Some({fn handler<S: ::logos::Source>(lex: &mut Lexer<S>) {
                     lex.bump();
                     #body
-                }))
+                } handler}))
             }
         }
     }

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -7,7 +7,7 @@
 //! This is a `#[derive]` macro crate, [for documentation go to main crate](https://docs.rs/logos).
 
 // The `quote!` macro requires deep recursion.
-#![recursion_limit = "128"]
+#![recursion_limit = "196"]
 
 extern crate syn;
 extern crate quote;
@@ -140,7 +140,7 @@ pub fn logos(input: TokenStream) -> TokenStream {
             const SIZE: usize = #size;
             const ERROR: Self = #name::#error;
 
-            fn lexicon<S: ::logos::Source>() -> ::logos::Lexicon<::logos::Lexer<Self, S>> {
+            fn lexicon<S: ::logos::Source>() -> &'static ::logos::Lexicon<::logos::Lexer<Self, S>> {
                 use ::logos::internal::LexerInternal;
 
                 type Lexer<S> = ::logos::Lexer<#name, S>;
@@ -157,7 +157,7 @@ pub fn logos(input: TokenStream) -> TokenStream {
 
                 #fns
 
-                [#(#handlers),*]
+                &[#(#handlers),*]
             }
         }
     };

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -140,7 +140,7 @@ pub fn logos(input: TokenStream) -> TokenStream {
             const SIZE: usize = #size;
             const ERROR: Self = #name::#error;
 
-            fn lexicon<S: ::logos::Source>() -> &'static ::logos::Lexicon<::logos::Lexer<Self, S>> {
+            fn lexicon<'a, S: ::logos::Source>() -> &'a ::logos::Lexicon<::logos::Lexer<Self, S>> {
                 use ::logos::internal::LexerInternal;
 
                 type Lexer<S> = ::logos::Lexer<#name, S>;

--- a/logos/Cargo.toml
+++ b/logos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logos"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["maciejhirsz <maciej.hirsz@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Create ridiculously fast Lexers"

--- a/logos/Cargo.toml
+++ b/logos/Cargo.toml
@@ -12,7 +12,8 @@ readme = "../README.md"
 toolshed = { version = "0.6", optional = true }
 
 [dev-dependencies]
-logos-derive = "0.2.3"
+# logos-derive = "0.2.3"
+logos-derive = { path = "../logos-derive" }
 
 [features]
 default = []

--- a/logos/src/lexer.rs
+++ b/logos/src/lexer.rs
@@ -14,7 +14,6 @@ pub struct Lexer<Token: Logos, Source> {
     source: Source,
     token_start: usize,
     token_end: usize,
-    // lexicon: Lexicon<Lexer<Token, Source>>,
 
     /// Current token. Call the `advance` method to get a new token.
     pub token: Token,
@@ -47,7 +46,6 @@ impl<Token: Logos, Src: Source> Lexer<Token, Src> {
             source,
             token_start: 0,
             token_end: 0,
-            // lexicon: Token::lexicon(),
             token: Token::ERROR,
             extras: Default::default(),
         };

--- a/logos/src/lexer.rs
+++ b/logos/src/lexer.rs
@@ -14,7 +14,7 @@ pub struct Lexer<Token: Logos, Source> {
     source: Source,
     token_start: usize,
     token_end: usize,
-    lexicon: Lexicon<Lexer<Token, Source>>,
+    // lexicon: Lexicon<Lexer<Token, Source>>,
 
     /// Current token. Call the `advance` method to get a new token.
     pub token: Token,
@@ -47,7 +47,7 @@ impl<Token: Logos, Src: Source> Lexer<Token, Src> {
             source,
             token_start: 0,
             token_end: 0,
-            lexicon: Token::lexicon(),
+            // lexicon: Token::lexicon(),
             token: Token::ERROR,
             extras: Default::default(),
         };
@@ -66,7 +66,7 @@ impl<Token: Logos, Src: Source> Lexer<Token, Src> {
         unwind! {
             ch = self.read();
 
-            if let Some(handler) = self.lexicon[ch as usize] {
+            if let Some(handler) = Token::lexicon()[ch as usize] {
                 self.token_start = self.token_end;
                 return handler(self);
             }

--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -116,7 +116,7 @@ pub trait Logos: Sized {
     const ERROR: Self;
 
     /// Returns a lookup table for the `Lexer`
-    fn lexicon<S: Source>() -> &'static Lexicon<Lexer<Self, S>>;
+    fn lexicon<'a, S: Source>() -> &'a Lexicon<Lexer<Self, S>>;
 
     /// Create a new instance of a `Lexer` that will produce tokens implementing
     /// this `Logos`.

--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -116,7 +116,7 @@ pub trait Logos: Sized {
     const ERROR: Self;
 
     /// Returns a lookup table for the `Lexer`
-    fn lexicon<S: Source>() -> Lexicon<Lexer<Self, S>>;
+    fn lexicon<S: Source>() -> &'static Lexicon<Lexer<Self, S>>;
 
     /// Create a new instance of a `Lexer` that will produce tokens implementing
     /// this `Logos`.


### PR DESCRIPTION
+ Using the closure syntax literal `|lex| { }` for handlers meant that the lookup table couldn't be made static, this is now fixed by explicitly using `fn` declarations.
+ `Logos::lexicon()` narrows the `&'static` lifetime to `&'a`, removing lifetime complaints form the Lexer.

Bonus points to @Vurich for figuring this out.