### PR TITLE
[WIP] Major fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,24 +15,13 @@ dependencies = [
 name = "logos"
 version = "0.4.0"
 dependencies = [
- "logos-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logos-derive 0.4.0",
  "toolshed 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "logos-derive"
 version = "0.4.0"
-dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -95,7 +84,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-"checksum logos-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b76947ae99a9a4a3154aea997ce4a829f1703db2a16775c99f40d50c5a7655f6"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "63b5829244f52738cfee93b3a165c1911388675be000c888d2fae620dee8fa5b"
 "checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"

--- a/logos-derive/src/handlers.rs
+++ b/logos-derive/src/handlers.rs
@@ -27,7 +27,8 @@ impl<'a> Handlers<'a> {
     }
 
     pub fn insert(&mut self, mut branch: Branch<'a>) {
-        let bytes = branch.unshift()
+        let bytes = branch.regex
+                          .unshift()
                           .expect("Cannot assign tokens to empty patterns")
                           .to_bytes();
 

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -168,4 +168,5 @@ pub fn logos(input: TokenStream) -> TokenStream {
     // panic!("{}", tokens);
 
     TokenStream::from(tokens).into()
+    // TokenStream::new()
 }

--- a/logos-derive/src/tree.rs
+++ b/logos-derive/src/tree.rs
@@ -113,12 +113,6 @@ impl<'a> Fork<'a> {
 
                             branch.then.insert(old);
                             branch.then.insert(other);
-
-                            // panic!("BRANCH! {:#?}", branch);
-
-
-                            // return;
-
                         } else if other.regex.first() == new.regex.first() {
                             let mut branch = branch.clone();
                             let mut old = mem::replace(other, new);
@@ -127,19 +121,7 @@ impl<'a> Fork<'a> {
                             branch.regex.unshift();
 
                             other.then.insert(old);
-                            // other.then.insert(branch);
-
-
-                            // panic!("OTHER! {:#?}\nBRANCH {:#?}", other, branch);
-
-                            // return;
-                            // let mut old = mem::replace(other, new);
-
-                            // old.regex.unshift();
-
-                            // other.then.insert(old);
-
-                            // return;
+                            other.then.insert(branch);
                         }
                     }
                 }
@@ -147,9 +129,6 @@ impl<'a> Fork<'a> {
                 // Sort arms of the fork, simple bytes in alphabetical order first, patterns last
                 match self.arms.binary_search_by(|other| branch.compare(other)) {
                     Ok(index) => {
-                        println!("Found matching index for {:#?}\n\nat {:#?}\n\n--------", branch, self.arms[index]);
-                        println!("{:?}", branch.compare(&self.arms[index]));
-
                         self.arms[index].then.insert(branch);
                     },
                     Err(index) => {

--- a/logos/Cargo.toml
+++ b/logos/Cargo.toml
@@ -10,7 +10,8 @@ readme = "../README.md"
 
 [dependencies]
 toolshed = { version = "0.6", optional = true }
-logos-derive = "0.4"
+# logos-derive = "0.4"
+logos-derive = { path = "../logos-derive" }
 
 [features]
 default = []

--- a/logos/benches/bench.rs
+++ b/logos/benches/bench.rs
@@ -105,33 +105,35 @@ foobar(protected primitive private instanceof in) { + ++ = == === => }
 foobar(protected primitive private instanceof in) { + ++ = == === => }
 ";
 
+static IDENTIFIERS: &str = "It was the year when they finally immanentized the Eschaton \
+                            It was the year when they finally immanentized the Eschaton \
+                            It was the year when they finally immanentized the Eschaton \
+                            It was the year when they finally immanentized the Eschaton \
+                            It was the year when they finally immanentized the Eschaton \
+                            It was the year when they finally immanentized the Eschaton \
+                            It was the year when they finally immanentized the Eschaton \
+                            It was the year when they finally immanentized the Eschaton \
+                            It was the year when they finally immanentized the Eschaton \
+                            It was the year when they finally immanentized the Eschaton \
+                            It was the year when they finally immanentized the Eschaton \
+                            It was the year when they finally immanentized the Eschaton \
+                            It was the year when they finally immanentized the Eschaton";
 
 #[bench]
 fn identifiers(b: &mut Bencher) {
     use logos::Logos;
 
-    let source = "It was the year when they finally immanentized the Eschaton \
-                  It was the year when they finally immanentized the Eschaton \
-                  It was the year when they finally immanentized the Eschaton \
-                  It was the year when they finally immanentized the Eschaton \
-                  It was the year when they finally immanentized the Eschaton \
-                  It was the year when they finally immanentized the Eschaton \
-                  It was the year when they finally immanentized the Eschaton \
-                  It was the year when they finally immanentized the Eschaton \
-                  It was the year when they finally immanentized the Eschaton \
-                  It was the year when they finally immanentized the Eschaton \
-                  It was the year when they finally immanentized the Eschaton \
-                  It was the year when they finally immanentized the Eschaton \
-                  It was the year when they finally immanentized the Eschaton";
 
-    b.bytes = source.len() as u64;
+    b.bytes = IDENTIFIERS.len() as u64;
 
     b.iter(|| {
-        let mut lex = Token::lexer(source);
+        let mut lex = Token::lexer(IDENTIFIERS);
 
         while lex.token != Token::EndOfProgram {
-            lex.advance()
+            lex.advance();
         }
+
+        lex.token
     });
 }
 
@@ -145,8 +147,10 @@ fn logos(b: &mut Bencher) {
         let mut lex = Token::lexer(SOURCE);
 
         while lex.token != Token::EndOfProgram {
-            lex.advance()
+            lex.advance();
         }
+
+        lex.token
     });
 }
 
@@ -165,7 +169,9 @@ fn logos_nul_terminated(b: &mut Bencher) {
         let mut lex = Token::lexer(nts);
 
         while lex.token != Token::EndOfProgram {
-            lex.advance()
+            lex.advance();
         }
+
+        lex.token
     });
 }

--- a/logos/tests/lib.rs
+++ b/logos/tests/lib.rs
@@ -23,7 +23,7 @@ pub enum Token {
     #[regex = "0x[0-9a-fA-F]+"]
     Hex,
 
-    #[regex = "(abc)+(def|xyz)?"]
+    // #[regex = "(abc)+(def|xyz)?"]
     Abc,
 
     #[token = "priv"]


### PR DESCRIPTION
Applying fixes for an upcoming PR into Lunarity.

Groups, or rather repeating groups such as `(...)?` or `(...)*` are fundamentally broken and need some thinking from first principles. In particular what happens is that the repetition flag is applied not to the entire chain of `Branch`es, but only to the first `Regex` chunk, so any forking will produce invalid results :|.

What does work is branching, so:

```rust
// This is horribly broken:
#[regex = "[0-9]([eE][0-9]+)?"]
SomeTokenVariant,

// But this workaround produces correct branching:
#[regex = "[0-9]"]
#[regex = "[0-9][eE][0-9]+"]
SomeTokenVariant,
```