### PR TITLE
Working on raw bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "logos"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "logos-derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toolshed 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -78,7 +78,7 @@ dependencies = [
 name = "tests"
 version = "0.0.0"
 dependencies = [
- "logos 0.6.2",
+ "logos 0.6.3",
  "logos-derive 0.6.0",
  "toolshed 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/logos/Cargo.toml
+++ b/logos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logos"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["maciejhirsz <maciej.hirsz@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Create ridiculously fast Lexers"

--- a/logos/Cargo.toml
+++ b/logos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logos"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["maciejhirsz <maciej.hirsz@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Create ridiculously fast Lexers"

--- a/logos/src/lexer.rs
+++ b/logos/src/lexer.rs
@@ -86,7 +86,7 @@ where
     }
 
     /// Get a string slice of the current token.
-    pub fn slice(&self) -> &'source str {
+    pub fn slice(&self) -> Source::Slice {
         unsafe { self.source.slice_unchecked(self.range()) }
     }
 }

--- a/logos/src/source.rs
+++ b/logos/src/source.rs
@@ -1,11 +1,12 @@
 use std::ops::Range;
+use std::fmt::Debug;
 
 /// Trait for a `Slice` of a `Source` that the `Lexer` can consume.
 ///
 /// Most commonly, those will be the same types:
 /// * `&str` slice for `&str` source.
 /// * `&[u8]` slice for `&[u8]` source.
-pub trait Slice<'source>: Sized {
+pub trait Slice<'source>: Sized + PartialEq + Eq + Debug {
     /// In all implementations we should at least be able to obtain a
     /// slice of bytes as the lowest level common denominator.
     fn as_bytes(&self) -> &'source [u8];

--- a/logos/src/source.rs
+++ b/logos/src/source.rs
@@ -1,11 +1,37 @@
 use std::ops::Range;
 
+/// Trait for a `Slice` of a `Source` that the `Lexer` can consume.
+///
+/// Most commonly, those will be the same types:
+/// * `&str` slice for `&str` source.
+/// * `&[u8]` slice for `&[u8]` source.
+pub trait Slice<'source>: Sized {
+    /// In all implementations we should at least be able to obtain a
+    /// slice of bytes as the lowest level common denominator.
+    fn as_bytes(&self) -> &'source [u8];
+}
+
+impl<'source> Slice<'source> for &'source str {
+    fn as_bytes(&self) -> &'source [u8] {
+        (*self).as_bytes()
+    }
+}
+
+impl<'source> Slice<'source> for &'source [u8] {
+    fn as_bytes(&self) -> &'source [u8] {
+        *self
+    }
+}
+
 /// Trait for types the `Lexer` can read from.
 ///
 /// Most notably this is implemented for `&str`. It is unlikely you will
 /// ever want to use this Trait yourself, unless implementing a new `Source`
 /// the `Lexer` can use.
 pub trait Source<'source> {
+    /// A type this `Source` can be sliced into.
+    type Slice: self::Slice<'source>;
+
     /// Length of the source
     fn len(&self) -> usize;
 
@@ -46,7 +72,7 @@ pub trait Source<'source> {
     /// }
     /// # }
     /// ```
-    fn slice(&self, range: Range<usize>) -> Option<&'source str>;
+    fn slice(&self, range: Range<usize>) -> Option<Self::Slice>;
 
     /// Get a slice of the source at given range. This is analogous to
     /// `slice::get_unchecked(range)`.
@@ -63,10 +89,12 @@ pub trait Source<'source> {
     /// }
     /// # }
     /// ```
-    unsafe fn slice_unchecked(&self, range: Range<usize>) -> &'source str;
+    unsafe fn slice_unchecked(&self, range: Range<usize>) -> Self::Slice;
 }
 
 impl<'source> Source<'source> for &'source str {
+    type Slice = &'source str;
+
     fn len(&self) -> usize {
         (*self).len()
     }
@@ -94,12 +122,44 @@ impl<'source> Source<'source> for &'source str {
     }
 }
 
+impl<'source> Source<'source> for &'source [u8] {
+    type Slice = &'source [u8];
+
+    fn len(&self) -> usize {
+        (*self).len()
+    }
+
+    unsafe fn read(&self, offset: usize) -> u8 {
+        debug_assert!(offset <= self.len(), "Reading out founds!");
+
+        match self.as_bytes().get(offset) {
+            Some(byte) => *byte,
+            None       => 0,
+        }
+    }
+
+    fn slice(&self, range: Range<usize>) -> Option<&'source [u8]> {
+        self.get(range)
+    }
+
+    unsafe fn slice_unchecked(&self, range: Range<usize>) -> &'source [u8] {
+        debug_assert!(
+            range.start <= self.len() && range.end <= self.len(),
+            "Reading out of bounds {:?} for {}!", range, self.len()
+        );
+
+        self.get_unchecked(range)
+    }
+}
+
 /// `Source` implemented on `NulTermStr` from the
 /// [`toolshed`](https://crates.io/crates/toolshed) crate.
 ///
 /// **This requires the `"nul_term_source"` feature to be enabled.**
 #[cfg(feature = "nul_term_source")]
 impl<'source> Source<'source> for toolshed::NulTermStr<'source> {
+    type Slice = &'source str;
+
     fn len(&self) -> usize {
         (**self).len()
     }

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -26,7 +26,10 @@ enum Token {
     LiteralFloat,
 }
 
-fn assert_lex(source: &str, tokens: &[(Token, &str, Range<usize>)]) {
+fn assert_lex<'a, Source>(source: Source, tokens: &[(Token, Source::Slice, Range<usize>)])
+where
+    Source: logos::Source<'a>,
+{
     let mut lex = Token::lexer(source);
 
     for tuple in tokens {

--- a/tests/tests/simple.rs
+++ b/tests/tests/simple.rs
@@ -103,7 +103,10 @@ enum Token {
     FatArrow,
 }
 
-fn assert_lex(source: &str, tokens: &[(Token, &str, Range<usize>)]) {
+fn assert_lex<'a, Source>(source: Source, tokens: &[(Token, Source::Slice, Range<usize>)])
+where
+    Source: logos::Source<'a>,
+{
     let mut lex = Token::lexer(source);
 
     for tuple in tokens {
@@ -275,5 +278,22 @@ mod simple {
         assert_eq!(lex.extras.tokens, 7); // End counts as a token
 
         assert_eq!(lex.extras.numbers, 2);
+    }
+
+    #[test]
+    fn u8_source() {
+        assert_lex(&b"It was the year when they finally immanentized the Eschaton."[..], &[
+            (Token::Identifier, b"It", 0..2),
+            (Token::Identifier, b"was", 3..6),
+            (Token::Identifier, b"the", 7..10),
+            (Token::Identifier, b"year", 11..15),
+            (Token::Identifier, b"when", 16..20),
+            (Token::Identifier, b"they", 21..25),
+            (Token::Identifier, b"finally", 26..33),
+            (Token::Identifier, b"immanentized", 34..46),
+            (Token::Identifier, b"the", 47..50),
+            (Token::Identifier, b"Eschaton", 51..59),
+            (Token::Accessor, b".", 59..60),
+        ]);
     }
 }


### PR DESCRIPTION
Closes #15 

This implements `Source` for raw byte slices `&[u8]`. The `Source` trait now, again, has an associated type `Slice` with a correct type of a slice.

This is a breaking change if you depended on using `&str` slices in callbacks. You can now instead use `Slice::as_bytes` to always get a `&[u8]` slice and work this way.