### PR TITLE
Full Unicode support!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,20 +13,10 @@ dependencies = [
 
 [[package]]
 name = "logos"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "logos-derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toolshed 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.6.0"
-dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -38,6 +28,17 @@ dependencies = [
  "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.7.0"
+dependencies = [
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -78,8 +79,8 @@ dependencies = [
 name = "tests"
 version = "0.0.0"
 dependencies = [
- "logos 0.7.0",
- "logos-derive 0.6.0",
+ "logos 0.7.1",
+ "logos-derive 0.7.0",
  "toolshed 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -101,6 +102,11 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "utf8-ranges"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
@@ -112,3 +118,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum toolshed 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d686c1f8d0a8c365f024145b31dfcd249c55b7ea17fc8bdcbae3844e16892233"
 "checksum ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0f8bfa9ff0cadcd210129ad9d2c5f145c13e9ced3d3e5d948a6213487d52444"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"

--- a/logos-derive/Cargo.toml
+++ b/logos-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logos-derive"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["maciejhirsz <maciej.hirsz@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Create ridiculously fast Lexers"
@@ -15,5 +15,6 @@ proc-macro = true
 [dependencies]
 syn = { version = "0.15", features = ["extra-traits", "full"] }
 quote = "0.6"
-proc-macro2 = "0.4.4"
+proc-macro2 = "0.4"
 regex-syntax = "0.6"
+utf8-ranges = "1.0"

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -14,6 +14,7 @@ extern crate quote;
 extern crate proc_macro;
 extern crate proc_macro2;
 extern crate regex_syntax;
+extern crate utf8_ranges;
 
 mod util;
 mod tree;

--- a/logos-derive/src/regex.rs
+++ b/logos-derive/src/regex.rs
@@ -198,6 +198,10 @@ impl Regex {
                 true
             },
             HirKind::Class(class) => {
+                if !class_is_ascii(&class) {
+                    return false;
+                }
+
                 match class {
                     Class::Unicode(unicode) => {
                         let mut class = unicode

--- a/logos-derive/src/regex.rs
+++ b/logos-derive/src/regex.rs
@@ -1,4 +1,5 @@
-use regex_syntax::hir::{self, Hir, HirKind};
+use utf8_ranges::{Utf8Sequences, Utf8Sequence, Utf8Range};
+use regex_syntax::hir::{self, Hir, HirKind, Class};
 use regex_syntax::Parser;
 use tree::{Node, Fork, ForkKind, Branch, Token};
 use std::cmp::Ordering;
@@ -119,6 +120,28 @@ impl<'a> Node<'a> {
 
                 Some(Node::from(fork))
             },
+            // This handles classes with non-ASCII Unicode ranges
+            HirKind::Class(ref class) if !class_is_ascii(class) => {
+                match class {
+                    Class::Unicode(unicode) => {
+                        let mut branches =
+                            unicode.iter()
+                                .flat_map(|range| Utf8Sequences::new(range.start(), range.end()))
+                                .map(|seq| Branch::new(seq.into()));
+
+                        branches.next().map(|branch| {
+                            let mut node = Node::Branch(branch);
+
+                            for branch in branches {
+                                node.insert(Node::Branch(branch));
+                            }
+
+                            node
+                        })
+                    },
+                    Class::Bytes(_) => panic!("Invalid Unicode codepoint in #[regex]."),
+                }
+            },
             _ => {
                 let mut regex = Regex::default();
 
@@ -150,14 +173,6 @@ impl Regex {
         }
     }
 
-    pub fn from(pat: Pattern) -> Regex {
-        let mut regex = Regex::default();
-
-        regex.patterns.push(pat);
-
-        regex
-    }
-
     fn from_hir_internal(hir: &HirKind, regex: &mut Regex) -> bool {
         match hir {
             HirKind::Empty => true,
@@ -183,8 +198,6 @@ impl Regex {
                 true
             },
             HirKind::Class(class) => {
-                use self::hir::{Class};
-
                 match class {
                     Class::Unicode(unicode) => {
                         let mut class = unicode
@@ -287,6 +300,64 @@ impl Regex {
     }
 }
 
+impl From<Pattern> for Regex {
+    fn from(pat: Pattern) -> Regex {
+        let mut regex = Regex::default();
+
+        regex.patterns.push(pat);
+
+        regex
+    }
+}
+
+impl From<Utf8Sequence> for Regex {
+    fn from(seq: Utf8Sequence) -> Self {
+        let patterns =
+            seq.as_slice()
+               .iter()
+               .cloned()
+               .map(Pattern::from)
+               .collect::<Vec<_>>();
+
+        Regex {
+            patterns,
+            offset: 0,
+        }
+    }
+}
+
+fn class_is_ascii(class: &Class) -> bool {
+    match class {
+        Class::Unicode(unicode) => {
+            unicode.iter().all(|range| {
+                let start = range.start() as u32;
+                let end = range.end() as u32;
+
+                start < 128 && end > 0 && (end < 128 || end == 0x10FFFF)
+            })
+        },
+        Class::Bytes(_) => false,
+    }
+}
+
+impl From<Utf8Range> for Pattern {
+    fn from(mut range: Utf8Range) -> Pattern {
+        if range.end == 0 {
+            panic!("Invalid Unicode codepoint in #[regex]");
+        }
+
+        if range.start == 0 {
+            range.start = 1;
+        }
+
+        if range.start == range.end {
+            Pattern::Byte(range.start)
+        } else {
+            Pattern::Range(range.start, range.end)
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum RepetitionFlag {
     ZeroOrMore,
@@ -305,7 +376,7 @@ fn format_ascii(byte: u8, f: &mut fmt::Formatter) -> fmt::Result {
     if byte >= 0x20 && byte <= 127 {
         write!(f, "{}", byte as char)
     } else {
-        write!(f, "{:?}", byte)
+        write!(f, "{:02X?}", byte)
     }
 }
 

--- a/logos/src/lexer.rs
+++ b/logos/src/lexer.rs
@@ -24,7 +24,7 @@ pub struct Lexer<Token: Logos, Source> {
     token_end: usize,
 }
 
-macro_rules! unwind {
+macro_rules! unroll {
     ($( $code:tt )*) => (
         $( $code )*
         $( $code )*
@@ -66,7 +66,7 @@ where
 
         self.extras.on_advance();
 
-        unwind! {
+        unroll! {
             ch = self.read();
 
             if let Some(handler) = Token::lexicon()[ch as usize] {

--- a/logos/src/source.rs
+++ b/logos/src/source.rs
@@ -68,9 +68,7 @@ pub trait Source<'source> {
     ///
     /// let foo = "It was the year when they finally immanentized the Eschaton.";
     ///
-    /// unsafe {
-    ///     assert_eq!(Source::slice(&foo, 51..59), Some("Eschaton"));
-    /// }
+    /// assert_eq!(Source::slice(&foo, 51..59), Some("Eschaton"));
     /// # }
     /// ```
     fn slice(&self, range: Range<usize>) -> Option<Self::Slice>;

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -24,6 +24,12 @@ enum Token {
 
     #[regex = "[0-9]*\\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+"]
     LiteralFloat,
+
+    #[regex = "🦀+"]
+    Rustaceans,
+
+    #[regex = "[ąęśćżźńół]+"]
+    Polish,
 }
 
 fn assert_lex<'a, Source>(source: Source, tokens: &[(Token, Source::Slice, Range<usize>)])
@@ -93,5 +99,26 @@ mod advanced {
             (Token::LiteralFloat, "42.9001e+12", 26..37),
             (Token::LiteralFloat, ".1e-3", 38..43),
         ]);
+    }
+
+    #[test]
+    fn rustaceans() {
+        assert_lex("🦀 🦀🦀 🦀🦀🦀 🦀🦀🦀🦀", &[
+            (Token::Rustaceans, "🦀", 0..4),
+            (Token::Rustaceans, "🦀🦀", 5..13),
+            (Token::Rustaceans, "🦀🦀🦀", 14..26),
+            (Token::Rustaceans, "🦀🦀🦀🦀", 27..43),
+        ]);
+    }
+
+    #[test]
+    fn polish() {
+        assert_lex("ą ę ó ąąąą łóżź", &[
+            (Token::Polish, "ą", 0..2),
+            (Token::Polish, "ę", 3..5),
+            (Token::Polish, "ó", 6..8),
+            (Token::Polish, "ąąąą", 9..17),
+            (Token::Polish, "łóżź", 18..26),
+        ])
     }
 }

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -30,6 +30,9 @@ enum Token {
 
     #[regex = "[ąęśćżźńół]+"]
     Polish,
+
+    #[regex = "[\\u0400-\\u04FF]+"]
+    Cyrillic,
 }
 
 fn assert_lex<'a, Source>(source: Source, tokens: &[(Token, Source::Slice, Range<usize>)])
@@ -119,6 +122,14 @@ mod advanced {
             (Token::Polish, "ó", 6..8),
             (Token::Polish, "ąąąą", 9..17),
             (Token::Polish, "łóżź", 18..26),
+        ])
+    }
+
+    #[test]
+    fn cyrillic() {
+        assert_lex("До свидания", &[
+            (Token::Cyrillic, "До", 0..4),
+            (Token::Cyrillic, "свидания", 5..21),
         ])
     }
 }


### PR DESCRIPTION
As per suggestion in #22 Logos will use `utf8_ranges` crate to create branching for non-ASCII Unicode ranges.