### PR TITLE
Crazy Lookup Table meta-macro hack!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,27 +13,15 @@ dependencies = [
 
 [[package]]
 name = "logos"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
- "logos-derive 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logos-derive 0.7.3",
  "toolshed 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.7.1"
-dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.3"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -80,8 +68,8 @@ dependencies = [
 name = "tests"
 version = "0.0.0"
 dependencies = [
- "logos 0.7.2",
- "logos-derive 0.7.1",
+ "logos 0.7.3",
+ "logos-derive 0.7.3",
  "toolshed 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -111,7 +99,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-"checksum logos-derive 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "858241ef3987c1d5c6b14c15d548d68c8684da001c634bec43ceb743d4a1826b"
 "checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"

--- a/logos-derive/Cargo.toml
+++ b/logos-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logos-derive"
-version = "0.7.1"
+version = "0.7.3"
 authors = ["maciejhirsz <maciej.hirsz@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Create ridiculously fast Lexers"

--- a/logos-derive/Cargo.toml
+++ b/logos-derive/Cargo.toml
@@ -6,6 +6,8 @@ license = "MIT/Apache-2.0"
 description = "Create ridiculously fast Lexers"
 repository = "https://github.com/maciejhirsz/logos"
 documentation = "https://docs.rs/logos-derive"
+keywords = ["lexer", "lexical", "tokenizer", "parser", "no_std"]
+categories = ["parsing", "text-processing"]
 readme = "../README.md"
 
 [lib]

--- a/logos-derive/src/util.rs
+++ b/logos-derive/src/util.rs
@@ -32,7 +32,7 @@ pub fn value_from_attr(name: &str, attr: &Attribute) -> Option<String> {
                     Err(_) => panic!("#[{}] value must be a literal string", name),
                 }
             },
-            Some(invalid) => panic!("#[extras] Invalid value: {}", invalid),
+            Some(invalid) => panic!("#[{}] Invalid value: {}", name, invalid),
             None => panic!("Invalid token")
         };
 

--- a/logos/Cargo.toml
+++ b/logos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logos"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["maciejhirsz <maciej.hirsz@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Create ridiculously fast Lexers"
@@ -12,7 +12,8 @@ readme = "../README.md"
 
 [dependencies]
 toolshed = { version = "0.6", optional = true }
-logos-derive = { version = "0.7", optional = true }
+# logos-derive = { version = "0.7.3", optional = true }
+logos-derive = { path = "../logos-derive", optional = true }
 
 [features]
 default = ["export_derive", "std"]

--- a/logos/Cargo.toml
+++ b/logos/Cargo.toml
@@ -6,6 +6,8 @@ license = "MIT/Apache-2.0"
 description = "Create ridiculously fast Lexers"
 repository = "https://github.com/maciejhirsz/logos"
 documentation = "https://docs.rs/logos"
+keywords = ["lexer", "lexical", "tokenizer", "parser", "no_std"]
+categories = ["parsing", "text-processing"]
 readme = "../README.md"
 
 [dependencies]

--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -139,7 +139,7 @@ pub trait Logos: Sized {
 }
 
 #[macro_export]
-macro_rules! map {
+macro_rules! lookup {
     ( $token:ident $($rest:tt)* ) => (
         $token!( $token $($rest)* )
     );

--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -137,3 +137,10 @@ pub trait Logos: Sized {
         Lexer::new(source)
     }
 }
+
+#[macro_export]
+macro_rules! map {
+    ( $token:ident $($rest:tt)* ) => (
+        $token!( $token $($rest)* )
+    );
+}

--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -138,6 +138,61 @@ pub trait Logos: Sized {
     }
 }
 
+/// Macro for creating lookup tables where index matches the token variant
+/// as `usize`.
+///
+/// This can be especially useful for creating Jump Tables using the static `fn()`
+/// function pointers, enabling an O(1) branching at the cost of introducing some
+/// indirection.
+///
+/// ```rust
+/// extern crate logos;
+///
+/// use logos::{Logos, lookup};
+///
+/// #[derive(Logos, Clone, Copy, PartialEq, Debug)]
+/// enum Token {
+///     #[end]
+///     End,
+///
+///     #[error]
+///     Error,
+///
+///     #[token = "Immanetize"]
+///     Immanetize,
+///
+///     #[token = "the"]
+///     The,
+///
+///     #[token = "Eschaton"]
+///     Eschaton,
+/// }
+///
+/// static LUT: [fn(u32) -> u32; Token::SIZE] = lookup! {
+///     // Rust is smart enough to convert closure syntax to `fn()`
+///     // pointers here, as long as we don't capture any values.
+///     Token::Eschaton => |n| n + 40,
+///     Token::Immanetize => |n| n + 8999,
+///     _ => |_| 0,
+/// };
+///
+/// fn main() {
+///     let mut lexer = Token::lexer("Immanetize the Eschaton");
+///
+///     assert_eq!(lexer.token, Token::Immanetize);
+///     assert_eq!(LUT[lexer.token as usize](2), 9001); // 2 + 8999
+///
+///     lexer.advance();
+///
+///     assert_eq!(lexer.token, Token::The);
+///     assert_eq!(LUT[lexer.token as usize](2), 0); // always 0
+///
+///     lexer.advance();
+///
+///     assert_eq!(lexer.token, Token::Eschaton);
+///     assert_eq!(LUT[lexer.token as usize](2), 42); // 2 + 40
+/// }
+/// ```
 #[macro_export]
 macro_rules! lookup {
     ( $token:ident $($rest:tt)* ) => (

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -2,7 +2,7 @@ extern crate logos;
 #[macro_use]
 extern crate logos_derive;
 
-use logos::{Logos, map};
+use logos::{Logos, lookup};
 use std::ops::Range;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
@@ -135,14 +135,14 @@ mod advanced {
 
     #[test]
     fn lookup() {
-        static MAP: [Option<&'static str>; Token::SIZE] = map! {
+        static LUT: [Option<&'static str>; Token::SIZE] = lookup! {
             Token::Polish => Some("Polish"),
             Token::Rustaceans => Some("🦀"),
             _ => None,
         };
 
-        assert_eq!(MAP[Token::Polish as usize], Some("Polish"));
-        assert_eq!(MAP[Token::Rustaceans as usize], Some("🦀"));
-        assert_eq!(MAP[Token::Cyrillic as usize], None);
+        assert_eq!(LUT[Token::Polish as usize], Some("Polish"));
+        assert_eq!(LUT[Token::Rustaceans as usize], Some("🦀"));
+        assert_eq!(LUT[Token::Cyrillic as usize], None);
     }
 }

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -2,7 +2,7 @@ extern crate logos;
 #[macro_use]
 extern crate logos_derive;
 
-use logos::Logos;
+use logos::{Logos, map};
 use std::ops::Range;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
@@ -122,7 +122,7 @@ mod advanced {
             (Token::Polish, "ó", 6..8),
             (Token::Polish, "ąąąą", 9..17),
             (Token::Polish, "łóżź", 18..26),
-        ])
+        ]);
     }
 
     #[test]
@@ -130,6 +130,19 @@ mod advanced {
         assert_lex("До свидания", &[
             (Token::Cyrillic, "До", 0..4),
             (Token::Cyrillic, "свидания", 5..21),
-        ])
+        ]);
+    }
+
+    #[test]
+    fn lookup() {
+        let map = map! {
+            Token::Polish => Some("Polish"),
+            Token::Rustaceans => Some("🦀"),
+            _ => None,
+        };
+
+        assert_eq!(map[Token::Polish as usize], Some("Polish"));
+        assert_eq!(map[Token::Rustaceans as usize], Some("🦀"));
+        assert_eq!(map[Token::Cyrillic as usize], None);
     }
 }

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -135,14 +135,14 @@ mod advanced {
 
     #[test]
     fn lookup() {
-        let map = map! {
+        static MAP: [Option<&'static str>; Token::SIZE] = map! {
             Token::Polish => Some("Polish"),
             Token::Rustaceans => Some("🦀"),
             _ => None,
         };
 
-        assert_eq!(map[Token::Polish as usize], Some("Polish"));
-        assert_eq!(map[Token::Rustaceans as usize], Some("🦀"));
-        assert_eq!(map[Token::Cyrillic as usize], None);
+        assert_eq!(MAP[Token::Polish as usize], Some("Polish"));
+        assert_eq!(MAP[Token::Rustaceans as usize], Some("🦀"));
+        assert_eq!(MAP[Token::Cyrillic as usize], None);
     }
 }


### PR DESCRIPTION
This adds a `lookup!` macro that can create static lookup tables matching token variants as indices to arbitrary static values.