### PR TITLE
v0.8.0: Callbacks per definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
 [[package]]
 name = "logos-derive"
 version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -32,8 +33,7 @@ dependencies = [
 
 [[package]]
 name = "logos-derive"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.8.0"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -81,7 +81,7 @@ name = "tests"
 version = "0.0.0"
 dependencies = [
  "logos 0.7.7",
- "logos-derive 0.7.7",
+ "logos-derive 0.8.0",
  "toolshed 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/logos-derive/Cargo.toml
+++ b/logos-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logos-derive"
-version = "0.7.7"
+version = "0.8.0"
 authors = ["maciejhirsz <maciej.hirsz@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Create ridiculously fast Lexers"

--- a/logos-derive/src/generator.rs
+++ b/logos-derive/src/generator.rs
@@ -393,7 +393,7 @@ impl<'a, 'b> SubGenerator<'a> for ExhaustiveGenerator<'a, 'b> {
         let name = self.gen().enum_name;
 
         let variant = leaf.token;
-        let callback = leaf.callback.or_else(|| self.gen().callbacks.get(variant));
+        let callback = leaf.callback.as_ref().or_else(|| self.gen().callbacks.get(variant));
 
         match callback {
             Some(callback) => {
@@ -430,7 +430,7 @@ impl<'a, 'b> SubGenerator<'a> for LooseGenerator<'a, 'b> {
         let name = self.gen().enum_name;
 
         let variant = leaf.token;
-        let callback = leaf.callback.or_else(|| self.gen().callbacks.get(variant));
+        let callback = leaf.callback.as_ref().or_else(|| self.gen().callbacks.get(variant));
 
         match callback {
             Some(callback) => {
@@ -469,7 +469,7 @@ impl<'a, 'b> SubGenerator<'a> for FallbackGenerator<'a, 'b> {
         let pattern_fn = self.gen.pattern_to_fn(&self.boundary);
 
         let variant = leaf.token;
-        let callback = leaf.callback.or_else(|| self.gen().callbacks.get(variant));
+        let callback = leaf.callback.as_ref().or_else(|| self.gen().callbacks.get(variant));
 
         match callback {
             Some(callback) => {

--- a/logos-derive/src/generator.rs
+++ b/logos-derive/src/generator.rs
@@ -5,7 +5,7 @@ use syn::Ident;
 use quote::{quote, ToTokens};
 use proc_macro2::{TokenStream, Span};
 
-use tree::{Node, Branch, ForkKind};
+use tree::{Node, Branch, ForkKind, Leaf};
 use regex::{Regex, Pattern};
 
 pub struct Generator<'a> {
@@ -175,7 +175,7 @@ pub trait SubGenerator<'a>: Sized {
 
     fn print(&mut self, node: &mut Node) -> TokenStream;
 
-    fn print_token(&mut self, variant: &Ident) -> TokenStream;
+    fn print_leaf(&mut self, leaf: &Leaf) -> TokenStream;
 
     fn print_then(&mut self, then: &mut Option<Box<Node>>) -> TokenStream {
         if let Some(node) = then {
@@ -274,7 +274,7 @@ pub trait SubGenerator<'a>: Sized {
         let is_bounded = node.is_bounded();
 
         match node {
-            Node::Token(token) => self.print_token(token),
+            Node::Leaf(leaf) => self.print_leaf(leaf),
             Node::Branch(branch) => self.print_branch(branch),
             Node::Fork(fork) => {
                 if fork.arms.len() == 0 {
@@ -389,10 +389,13 @@ impl<'a, 'b> SubGenerator<'a> for ExhaustiveGenerator<'a, 'b> {
         quote!(lex.token = #body;)
     }
 
-    fn print_token(&mut self, variant: &Ident) -> TokenStream {
+    fn print_leaf(&mut self, leaf: &Leaf) -> TokenStream {
         let name = self.gen().enum_name;
 
-        match self.gen().callbacks.get(variant) {
+        let variant = leaf.token;
+        let callback = leaf.callback.or_else(|| self.gen().callbacks.get(variant));
+
+        match callback {
             Some(callback) => {
                 quote!({
                     lex.token = #name::#variant;
@@ -423,10 +426,13 @@ impl<'a, 'b> SubGenerator<'a> for LooseGenerator<'a, 'b> {
         }
     }
 
-    fn print_token(&mut self, variant: &Ident) -> TokenStream {
+    fn print_leaf(&mut self, leaf: &Leaf) -> TokenStream {
         let name = self.gen().enum_name;
 
-        match self.gen().callbacks.get(variant) {
+        let variant = leaf.token;
+        let callback = leaf.callback.or_else(|| self.gen().callbacks.get(variant));
+
+        match callback {
             Some(callback) => {
                 quote!({
                     lex.token = #name::#variant;
@@ -458,12 +464,14 @@ impl<'a, 'b> SubGenerator<'a> for FallbackGenerator<'a, 'b> {
         }
     }
 
-    fn print_token(&mut self, variant: &Ident) -> TokenStream {
+    fn print_leaf(&mut self, leaf: &Leaf) -> TokenStream {
         let name = self.gen().enum_name;
         let pattern_fn = self.gen.pattern_to_fn(&self.boundary);
 
+        let variant = leaf.token;
+        let callback = leaf.callback.or_else(|| self.gen().callbacks.get(variant));
 
-        match self.gen().callbacks.get(variant) {
+        match callback {
             Some(callback) => {
                 quote! {
                     if !#pattern_fn(lex.read()) {
@@ -515,8 +523,8 @@ where
         self.0.print(node)
     }
 
-    fn print_token(&mut self, variant: &Ident) -> TokenStream {
-        self.0.print_token(variant)
+    fn print_leaf(&mut self, leaf: &Leaf) -> TokenStream {
+        self.0.print_leaf(leaf)
     }
 
     fn print_fallback(&mut self) -> TokenStream {
@@ -552,8 +560,8 @@ where
         self.0.print(node)
     }
 
-    fn print_token(&mut self, variant: &Ident) -> TokenStream {
-        self.0.print_token(variant)
+    fn print_leaf(&mut self, leaf: &Leaf) -> TokenStream {
+        self.0.print_leaf(leaf)
     }
 
     fn print_fallback(&mut self) -> TokenStream {

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -22,7 +22,7 @@ mod regex;
 mod handlers;
 mod generator;
 
-use tree::{Node, Fork};
+use tree::{Node, Fork, Leaf};
 use util::{OptionExt, value_from_attr};
 use handlers::Handlers;
 use generator::Generator;
@@ -93,12 +93,17 @@ pub fn logos(input: TokenStream) -> TokenStream {
                 end.insert(variant, |_| panic!("Only one #[end] variant can be declared."));
             }
 
+            let leaf = Leaf {
+                token: variant,
+                callback: None,
+            };
+
             if let Some(path) = value_from_attr("token", attr) {
-                fork.insert(Node::from_sequence(&path, variant));
+                fork.insert(Node::from_sequence(&path, leaf));
             }
 
             if let Some(path) = value_from_attr("regex", attr) {
-                fork.insert(Node::from_regex(&path, variant));
+                fork.insert(Node::from_regex(&path, leaf));
             }
 
             if let Some(callback) = value_from_attr("callback", attr) {

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -8,10 +8,10 @@ use std::ops::Range;
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
 enum Token {
     #[error]
-    InvalidToken,
+    Error,
 
     #[end]
-    EndOfProgram,
+    End,
 
     #[regex = "\"([^\"\\\\]|\\\\.)*\""]
     LiteralString,
@@ -50,7 +50,7 @@ where
         lex.advance();
     }
 
-    assert_eq!(lex.token, Token::EndOfProgram);
+    assert_eq!(lex.token, Token::End);
 }
 
 mod advanced {
@@ -69,8 +69,8 @@ mod advanced {
     #[test]
     fn hex() {
         assert_lex("0x 0X 0x0 0x9 0xa 0xf 0X0 0X9 0XA 0XF 0x123456789abcdefABCDEF 0xdeadBEEF", &[
-            (Token::InvalidToken, "0x", 0..2),
-            (Token::InvalidToken, "0X", 3..5),
+            (Token::Error, "0x", 0..2),
+            (Token::Error, "0X", 3..5),
             (Token::LiteralHex, "0x0", 6..9),
             (Token::LiteralHex, "0x9", 10..13),
             (Token::LiteralHex, "0xa", 14..17),

--- a/tests/tests/properties.rs
+++ b/tests/tests/properties.rs
@@ -8,10 +8,10 @@ use std::ops::Range;
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
 enum Token {
     #[error]
-    InvalidToken,
+    Error,
 
     #[end]
-    EndOfProgram,
+    End,
 
     #[regex = r"[a-zA-Z]+"]
     Ascii,
@@ -35,7 +35,7 @@ where
         lex.advance();
     }
 
-    assert_eq!(lex.token, Token::EndOfProgram);
+    assert_eq!(lex.token, Token::End);
 }
 
 mod properties {


### PR DESCRIPTION
This allows for defining callbacks per variant definition. Before you could write something like:

```rust
#[derive(Logos)]
enum Token {
    // ...

    #[token = "foo"]
    #[regex = "bar"]
    #[callback = "check_foo_or_bar"]
    VariantWithCallback,

    // ...
}
```

Which would invoke the `check_foo_or_bar()` callback on either `"foo"` or `"bar"` tokens. There was no way to differentiate between those, spare checking the token slice within the callback.

It's now possible to define callbacks per variant _definition_, not just enum variant itself:

```rust
#[derive(Logos)]
enum Token {
    // ...

    #[token("foo", callback = "check_foo")]
    #[regex("bar", callback = "check_bar")]
    VariantWithCallback,

    // ...
}
```

This will invoke `check_foo()` only for `"foo"` tokens, and `check_bar()` only for `"bar"` tokens.

To make this syntax possible `#[token("...")]` or `#[regex("...")]` is now equivalent to `#[token = "..."]` or `#[regex = "..."]`. In the future having the option to define extra arguments on definitions should allow us to do things like set priorities to disambiguate conflicting definitions (#16).