### PR TITLE
Remove spurious use of logos_derive

### DIFF
--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -1,5 +1,4 @@
 use logos::{Logos, lookup};
-use logos_derive::Logos;
 use std::ops::Range;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]

--- a/tests/tests/properties.rs
+++ b/tests/tests/properties.rs
@@ -1,5 +1,4 @@
 use logos::Logos;
-use logos_derive::Logos;
 use std::ops::Range;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]

--- a/tests/tests/simple.rs
+++ b/tests/tests/simple.rs
@@ -1,5 +1,4 @@
 use logos::{Logos, Extras, Lexer};
-use logos_derive::Logos;
 use std::ops::Range;
 
 #[derive(Default)]


### PR DESCRIPTION
On nightly these additional uses end with error
```
error[E0252]: the name `Logos` is defined multiple times
 --> tests/tests/advanced.rs:2:5
  |
1 | use logos::{Logos, lookup};
  |             ----- previous import of the macro `Logos` here
2 | use logos_derive::Logos;
  |     ^^^^^^^^^^^^^^^^^^^ `Logos` reimported here
  |
  = note: `Logos` must be defined only once in the macro namespace of this module
help: you can use `as` to change the binding name of the import
```