### PR TITLE
Trigger fork bug again

### DIFF
--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -25,6 +25,9 @@ enum Token {
     #[token="~"]
     LiteralNull,
 
+    #[token="~["]
+    Sglc,
+
     #[regex="~[a-z][a-z]+"]
     LiteralUrbitAddress,
 

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -25,6 +25,12 @@ enum Token {
     #[token="~"]
     LiteralNull,
 
+    #[token="~?"]
+    Sgwt, 
+
+    #[token="~%"]
+    Sgcn, 
+
     #[token="~["]
     Sglc,
 


### PR DESCRIPTION
Unfortunately the ghost has returned, and simply adding another token 
```
#[token="~["]
Sglc
```
somehow messes up the tree structure, so that `LiteralUrbitAddress` which is branching off common point 
for `LiteralRelDate` is unrecognized again. 