### PR TITLE
Fix intersection branching

### DIFF
--- a/logos-derive/Cargo.toml
+++ b/logos-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logos-derive"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["maciejhirsz <maciej.hirsz@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Create ridiculously fast Lexers"

--- a/tests/benches/bench.rs
+++ b/tests/benches/bench.rs
@@ -118,11 +118,31 @@ static IDENTIFIERS: &str = "It was the year when they finally immanentized the E
 fn identifiers(b: &mut Bencher) {
     use logos::Logos;
 
-
     b.bytes = IDENTIFIERS.len() as u64;
 
     b.iter(|| {
         let mut lex = Token::lexer(IDENTIFIERS);
+
+        while lex.token != Token::EndOfProgram {
+            lex.advance();
+        }
+
+        lex.token
+    });
+}
+
+#[bench]
+fn identifiers_nul_terminated(b: &mut Bencher) {
+    use logos::Logos;
+    use toolshed::Arena;
+
+    let arena = Arena::new();
+    let nts = arena.alloc_nul_term_str(IDENTIFIERS);
+
+    b.bytes = IDENTIFIERS.len() as u64;
+
+    b.iter(|| {
+        let mut lex = Token::lexer(nts);
 
         while lex.token != Token::EndOfProgram {
             lex.advance();

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -38,7 +38,7 @@ enum Token {
     LiteralUrbitAddress,
 
     #[regex="~[0-9]+-?[\\.0-9a-f]+"]
-    LiteralAbsDate, 
+    LiteralAbsDate,
 
     #[regex="~[mhs][0-9]+"]
     LiteralRelDate,


### PR DESCRIPTION
Fixes the issue detected with #49.

Moved the `is_finite` check from the entire fork to just the branch on which we test intersection prefixes, since that's the only case where we could get a stack overflow (by repeatedly unwinding an arm that ends with a `Repeat` fork).

CC @mikolajpp 