### PR TITLE
0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,9 @@
 [[package]]
+name = "byteorder"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "logos"
 version = "0.9.7"
 dependencies = [
@@ -12,6 +17,7 @@ dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -38,6 +44,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -74,9 +88,11 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
+"checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,36 +1,18 @@
 [[package]]
-name = "byteorder"
-version = "1.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "logos"
 version = "0.9.7"
 dependencies = [
- "logos-derive 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "toolshed 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logos-derive 0.10.0",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -52,23 +34,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "syn"
-version = "0.15.22"
+version = "0.15.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -81,16 +55,7 @@ name = "tests"
 version = "0.0.0"
 dependencies = [
  "logos 0.9.7",
- "logos-derive 0.9.7",
- "toolshed 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "toolshed"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logos-derive 0.10.0",
 ]
 
 [[package]]
@@ -109,14 +74,10 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
-"checksum logos-derive 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)" = "13ff1b1068db09ee21d12baf55eccc0900a781a735273e0a606f6f4fbb32a322"
 "checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
-"checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
-"checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
-"checksum syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)" = "ae8b29eb5210bc5cf63ed6149cbf9adfc82ac0be023d8735c176ee74a2db4da7"
-"checksum toolshed 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8d2a2c31273526c0c85f79642dba51e95b25c5cb3addef94ca97e680d547dbbf"
+"checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
+"checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ fn main() {
 Ridiculously fast!
 
 ```
-test logos                ... bench:       2,005 ns/iter (+/- 16) = 1062 MB/s
-test logos_nul_terminated ... bench:       1,828 ns/iter (+/- 69) = 1165 MB/s
+test identifiers                       ... bench:         673 ns/iter (+/- 7) = 1157 MB/s
+test keywords_operators_and_punctators ... bench:       1,803 ns/iter (+/- 60) = 1181 MB/s
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ fn main() {
 Ridiculously fast!
 
 ```
-test identifiers                       ... bench:         673 ns/iter (+/- 7) = 1157 MB/s
-test keywords_operators_and_punctators ... bench:       1,803 ns/iter (+/- 60) = 1181 MB/s
+test identifiers                       ... bench:         667 ns/iter (+/- 1) = 1167 MB/s
+test keywords_operators_and_punctators ... bench:       1,807 ns/iter (+/- 44) = 1179 MB/ss
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ fn main() {
 Ridiculously fast!
 
 ```
-test identifiers                       ... bench:         667 ns/iter (+/- 1) = 1167 MB/s
-test keywords_operators_and_punctators ... bench:       1,807 ns/iter (+/- 44) = 1179 MB/ss
+test identifiers                       ... bench:         677 ns/iter (+/- 2) = 1150 MB/s
+test keywords_operators_and_punctators ... bench:       1,780 ns/iter (+/- 27) = 1197 MB/s
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ fn main() {
 Ridiculously fast!
 
 ```
-test identifiers                       ... bench:         677 ns/iter (+/- 2) = 1150 MB/s
-test keywords_operators_and_punctators ... bench:       1,780 ns/iter (+/- 27) = 1197 MB/s
+test identifiers                       ... bench:         675 ns/iter (+/- 3) = 1154 MB/s
+test keywords_operators_and_punctators ... bench:       1,814 ns/iter (+/- 16) = 1174 MB/s
 ```
 
 ## License

--- a/logos-derive/Cargo.toml
+++ b/logos-derive/Cargo.toml
@@ -16,6 +16,7 @@ name = "logos_derive"
 proc-macro = true
 
 [dependencies]
+rustc-hash = "1.0.1"
 syn = { version = "0.15", features = ["extra-traits", "full"] }
 quote = "0.6"
 proc-macro2 = "0.4"

--- a/logos-derive/Cargo.toml
+++ b/logos-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logos-derive"
-version = "0.9.7"
+version = "0.10.0"
 authors = ["maciejhirsz <maciej.hirsz@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Create ridiculously fast Lexers"

--- a/logos-derive/src/generator.rs
+++ b/logos-derive/src/generator.rs
@@ -270,7 +270,7 @@ pub trait CodeGenerator<'a>: Sized {
         self.print_then(then, ctx)
     }
 
-    fn print_lex_read<Code>(&mut self, code: Code, default: MatchDefault, bytes: usize, ctx: Context) -> TokenStream
+    fn print_lex_read<Code>(&mut self, default: MatchDefault, bytes: usize, ctx: Context, code: Code) -> TokenStream
     where
         Code: FnOnce(&mut Self, Context) -> TokenStream,
     {
@@ -309,10 +309,9 @@ pub trait CodeGenerator<'a>: Sized {
                 return self.print_simple_branch(branch, ctx);
             }
 
-            // let branch = self.print_branch(branch, Context::new(read));
-            let branch = |gen: &mut Self, ctx| gen.print_branch(branch, ctx);
-
-            return self.print_lex_read(branch, MatchDefault::None, read, ctx);
+            return self.print_lex_read(MatchDefault::None, read, ctx, |gen: &mut Self, ctx| {
+                gen.print_branch(branch, ctx)
+            });
         }
 
         let (source, split) = if ctx.available > len {
@@ -395,9 +394,9 @@ pub trait CodeGenerator<'a>: Sized {
                 },
             };
 
-            let fork = |gen: &mut Self, ctx| gen.print_fork_as_match(fork, ctx);
-
-            return self.print_lex_read(fork, default, read, ctx);
+            return self.print_lex_read(default, read, ctx, |gen, ctx| {
+                gen.print_fork_as_match(fork, ctx)
+            });
         }
 
         let kind = fork.kind;
@@ -801,7 +800,7 @@ where
         };
     }
 
-    fn print_lex_read<Code>(&mut self, code: Code, default: MatchDefault, bytes: usize, ctx: Context) -> TokenStream
+    fn print_lex_read<Code>(&mut self, default: MatchDefault, bytes: usize, ctx: Context, code: Code) -> TokenStream
     where
         Code: FnOnce(&mut Self, Context) -> TokenStream,
     {
@@ -900,7 +899,7 @@ where
         };
     }
 
-    fn print_lex_read<Code>(&mut self, code: Code, default: MatchDefault, bytes: usize, ctx: Context) -> TokenStream
+    fn print_lex_read<Code>(&mut self, default: MatchDefault, bytes: usize, ctx: Context, code: Code) -> TokenStream
     where
         Code: FnOnce(&mut Self, Context) -> TokenStream,
     {

--- a/logos-derive/src/generator.rs
+++ b/logos-derive/src/generator.rs
@@ -142,11 +142,8 @@ impl<'a> Generator<'a> {
         // At this point all Rc pointers should be unique
         let tree = Rc::make_mut(&mut tree);
 
-        if let Some(Fallback { boundary, leaf }) = &tree.fallback {
-            let regex = Regex::from(boundary.clone());
-            let mut then = Some(Node::Leaf(leaf.clone()).boxed());
-
-            let fallback = self.print_simple_repeat(&regex, &mut then, Context::new(0));
+        if let Some(Fallback { boundary, fork }) = &mut tree.fallback {
+            let fallback = self.print_fork(fork, Context::new(0));
 
             FallbackGenerator {
                 gen: self,

--- a/logos-derive/src/generator.rs
+++ b/logos-derive/src/generator.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::rc::Rc;
 use syn::Ident;
 use quote::{quote, ToTokens};
 use proc_macro2::{TokenStream, Span};
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::tree::{Node, Branch, ForkKind, Leaf};
 use crate::regex::{Regex, Pattern};
@@ -29,9 +29,9 @@ impl<'a> Generator<'a> {
         Generator {
             enum_name,
             fns: TokenStream::new(),
-            fns_constructed: HashMap::new(),
-            patterns: HashMap::new(),
-            callbacks: HashMap::new(),
+            fns_constructed: HashMap::default(),
+            patterns: HashMap::default(),
+            callbacks: HashMap::default(),
         }
     }
 

--- a/logos-derive/src/generator.rs
+++ b/logos-derive/src/generator.rs
@@ -195,7 +195,7 @@ pub trait SubGenerator<'a>: Sized {
         }
 
         let (first, rest, bump) = self.regex_to_test(branch.regex.patterns());
-        let next = self.print_branch(branch);
+        let next = self.print_then(&mut branch.then);
 
         quote! {
             if #first #(&& #rest)* {

--- a/logos-derive/src/generator.rs
+++ b/logos-derive/src/generator.rs
@@ -301,8 +301,8 @@ pub trait SubGenerator<'a>: Sized {
         let test = patterns.chunks(16).enumerate().map(|(idx, chunk)| {
             let offset = 16 * idx;
             let chunk_type = match chunk.len() {
-                1 => quote!(u8),
-                _ => quote!(&[u8; #len]),
+                1   => quote!(u8),
+                len => quote!(&[u8; #len]),
             };
 
             let source = match offset {

--- a/logos-derive/src/generator.rs
+++ b/logos-derive/src/generator.rs
@@ -193,12 +193,10 @@ impl<'a> Generator<'a> {
                     }
                 },
                 _ => {
-                    let bytes: Vec<u8> = pattern.to_bytes();
-
                     let mut table = [false; 256];
 
-                    for byte in bytes {
-                        table[byte as usize] = true;
+                    for byte in pattern.to_bytes(&mut [0; 256]) {
+                        table[*byte as usize] = true;
                     }
 
                     let ltrue = quote!(TT);

--- a/logos-derive/src/handlers.rs
+++ b/logos-derive/src/handlers.rs
@@ -4,7 +4,6 @@ use crate::tree::{Node, Branch};
 
 #[derive(Debug, Clone)]
 pub enum Handler<'a> {
-    Eof,
     Error,
     Whitespace,
     Tree(Rc<Node<'a>>),
@@ -19,8 +18,7 @@ impl<'a> Handlers<'a> {
     pub fn new() -> Self {
         let mut handlers = vec![Handler::Error; 256];
 
-        handlers[0] = Handler::Eof;
-        handlers[1..33].iter_mut().for_each(|slot| *slot = Handler::Whitespace);
+        handlers[0..33].iter_mut().for_each(|slot| *slot = Handler::Whitespace);
 
         Handlers {
             handlers

--- a/logos-derive/src/handlers.rs
+++ b/logos-derive/src/handlers.rs
@@ -28,9 +28,8 @@ pub struct Handlers<'a> {
 }
 
 pub enum Trivia {
-    Pattern(Pattern),
+    Patterns(Vec<Pattern>),
     Default,
-    None,
 }
 
 impl<'a> Handlers<'a> {
@@ -38,15 +37,14 @@ impl<'a> Handlers<'a> {
         let mut handlers = vec![Handler::Error; 256];
 
         match trivia {
-            Trivia::Pattern(pat) => {
-                for byte in pat.bytes() {
+            Trivia::Patterns(patterns) => {
+                for byte in patterns.iter().map(|pat| pat.bytes()).flatten() {
                     handlers[byte as usize] = Handler::Whitespace;
                 }
             },
             Trivia::Default => {
                 handlers[0..33].iter_mut().for_each(|slot| *slot = Handler::Whitespace);
             },
-            Trivia::None => {}
         }
 
         Handlers {

--- a/logos-derive/src/handlers.rs
+++ b/logos-derive/src/handlers.rs
@@ -28,6 +28,7 @@ pub struct Handlers<'a> {
 }
 
 pub enum Trivia {
+    Pattern(Pattern),
     Default,
     None,
 }
@@ -37,6 +38,11 @@ impl<'a> Handlers<'a> {
         let mut handlers = vec![Handler::Error; 256];
 
         match trivia {
+            Trivia::Pattern(pat) => {
+                for byte in pat.bytes() {
+                    handlers[byte as usize] = Handler::Whitespace;
+                }
+            },
             Trivia::Default => {
                 handlers[0..33].iter_mut().for_each(|slot| *slot = Handler::Whitespace);
             },

--- a/logos-derive/src/handlers.rs
+++ b/logos-derive/src/handlers.rs
@@ -27,11 +27,21 @@ pub struct Handlers<'a> {
     handlers: Vec<Handler<'a>>,
 }
 
+pub enum Trivia {
+    Default,
+    None,
+}
+
 impl<'a> Handlers<'a> {
-    pub fn new() -> Self {
+    pub fn new(trivia: Trivia) -> Self {
         let mut handlers = vec![Handler::Error; 256];
 
-        handlers[0..33].iter_mut().for_each(|slot| *slot = Handler::Whitespace);
+        match trivia {
+            Trivia::Default => {
+                handlers[0..33].iter_mut().for_each(|slot| *slot = Handler::Whitespace);
+            },
+            Trivia::None => {}
+        }
 
         Handlers {
             handlers

--- a/logos-derive/src/handlers.rs
+++ b/logos-derive/src/handlers.rs
@@ -39,7 +39,7 @@ impl<'a> Handlers<'a> {
     }
 
     pub fn insert(&mut self, mut branch: Branch<'a>) {
-        let bytes = branch.regex.unshift().to_bytes();
+        let pattern = branch.regex.unshift();
 
         let tree = Rc::new(Tree {
             node: Node::from(branch),
@@ -48,8 +48,8 @@ impl<'a> Handlers<'a> {
 
         let fallback = tree.node.fallback();
 
-        for byte in bytes {
-            match self.handlers[byte as usize] {
+        for byte in pattern.to_bytes(&mut [0; 256]) {
+            match self.handlers[*byte as usize] {
                 Handler::Tree(ref mut tree) => {
                     let tree = Rc::make_mut(tree);
 

--- a/logos-derive/src/handlers.rs
+++ b/logos-derive/src/handlers.rs
@@ -26,10 +26,7 @@ impl<'a> Handlers<'a> {
     }
 
     pub fn insert(&mut self, mut branch: Branch<'a>) {
-        let bytes = branch.regex
-                          .unshift()
-                          .expect("Cannot assign tokens to empty patterns")
-                          .to_bytes();
+        let bytes = branch.regex.unshift().to_bytes();
 
         let node = Rc::new(Node::from(branch));
 

--- a/logos-derive/src/handlers.rs
+++ b/logos-derive/src/handlers.rs
@@ -54,8 +54,8 @@ impl<'a> Handlers<'a> {
             fallback,
         });
 
-        for byte in pattern.to_bytes(&mut [0; 256]) {
-            self.handlers[*byte as usize] = Handler::Tree(tree.clone());
+        for byte in pattern.bytes() {
+            self.handlers[byte as usize] = Handler::Tree(tree.clone());
         }
     }
 

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -161,6 +161,7 @@ pub fn logos(input: TokenStream) -> TokenStream {
     let tokens = quote! {
         impl ::logos::Logos for #name {
             type Extras = #extras;
+            type SourceMarker = ::logos::source::AnySource;
 
             const SIZE: usize = #size;
             const ERROR: Self = #name::#error;

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -136,8 +136,8 @@ pub fn logos(input: TokenStream) -> TokenStream {
 
     let handlers = handlers.into_iter().map(|handler| {
         match handler {
-            Handler::Error      => quote! { Some(_error) },
-            Handler::Whitespace => quote! { None },
+            Handler::Error      => quote!(Some(_error)),
+            Handler::Whitespace => quote!(None),
             Handler::Tree(tree) => generator.print_tree(tree),
         }
     }).collect::<Vec<_>>();

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -100,7 +100,7 @@ pub fn logos(input: TokenStream) -> TokenStream {
             } else if let Some(definition) = value_from_attr::<VariantDefinition>("regex", attr) {
                 leaf.callback = definition.callback;
 
-                fork.insert(Node::from_regex(&definition.value, leaf));
+                fork.insert(Node::from_regex(&definition.value, Some(leaf)));
             }
 
             if let Some(callback) = value_from_attr("callback", attr) {

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -134,7 +134,6 @@ pub fn logos(input: TokenStream) -> TokenStream {
 
     let handlers = handlers.into_iter().map(|handler| {
         match handler {
-            Handler::Eof        => quote! { Some(eof) },
             Handler::Error      => quote! { Some(_error) },
             Handler::Whitespace => quote! { None },
             Handler::Tree(tree) => generator.print_tree(tree),
@@ -169,10 +168,6 @@ pub fn logos(input: TokenStream) -> TokenStream {
                 use ::logos::internal::LexerInternal;
 
                 type Lexer<S> = ::logos::Lexer<#name, S>;
-
-                fn eof<'source, S: ::logos::Source<'source>>(lex: &mut Lexer<S>) {
-                    lex.token = #name::#end;
-                }
 
                 fn _error<'source, S: ::logos::Source<'source>>(lex: &mut Lexer<S>) {
                     lex.bump(1);

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -109,6 +109,8 @@ pub fn logos(input: TokenStream) -> TokenStream {
         }
     }
 
+    fork.pack();
+
     // panic!("{:#?}", fork);
 
     for branch in fork.arms.drain(..) {

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -161,13 +161,16 @@ pub fn logos(input: TokenStream) -> TokenStream {
     let tokens = quote! {
         impl ::logos::Logos for #name {
             type Extras = #extras;
-            type SourceMarker = ::logos::source::AnySource;
 
             const SIZE: usize = #size;
             const ERROR: Self = #name::#error;
             const END: Self = #name::#end;
 
-            fn lexicon<'lexicon, 'source, S: ::logos::Source<'source>>() -> &'lexicon ::logos::Lexicon<::logos::Lexer<Self, S>> {
+            fn lexicon<'lexicon, 'source, Source>() -> &'lexicon ::logos::Lexicon<::logos::Lexer<Self, Source>>
+            where
+                Source: ::logos::Source<'source>,
+                Self: ::logos::source::WithSource<Source>,
+            {
                 use ::logos::internal::LexerInternal;
                 use ::logos::source::Split;
 
@@ -184,6 +187,8 @@ pub fn logos(input: TokenStream) -> TokenStream {
                 &[#(#handlers),*]
             }
         }
+
+        impl<'source, Source: ::logos::Source<'source>> ::logos::source::WithSource<Source> for #name {}
 
         #[macro_export]
         #[doc(hidden)]

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -168,6 +168,7 @@ pub fn logos(input: TokenStream) -> TokenStream {
 
             fn lexicon<'lexicon, 'source, S: ::logos::Source<'source>>() -> &'lexicon ::logos::Lexicon<::logos::Lexer<Self, S>> {
                 use ::logos::internal::LexerInternal;
+                use ::logos::source::Split;
 
                 type Lexer<S> = ::logos::Lexer<#name, S>;
 

--- a/logos-derive/src/regex.rs
+++ b/logos-derive/src/regex.rs
@@ -1,11 +1,13 @@
 use utf8_ranges::{Utf8Sequences, Utf8Sequence, Utf8Range};
 use regex_syntax::hir::{self, Hir, HirKind, Class};
 use regex_syntax::ParserBuilder;
-use std::cmp::Ordering;
 use std::fmt;
 
-use crate::util::{MergeAscending, DiffAscending};
 use crate::tree::{Node, Fork, ForkKind, Branch, Leaf};
+
+mod pattern;
+
+pub use self::pattern::Pattern;
 
 #[derive(Clone, Default, PartialEq, Eq, Hash)]
 pub struct Regex {
@@ -376,41 +378,6 @@ pub enum RepetitionFlag {
     ZeroOrOne,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub enum Pattern {
-    Byte(u8),
-    Range(u8, u8),
-    Class(Vec<Pattern>),
-}
-
-fn format_ascii(byte: u8, f: &mut fmt::Formatter) -> fmt::Result {
-    if byte >= 0x20 && byte <= 127 {
-        write!(f, "{}", byte as char)
-    } else {
-        write!(f, "{:02X?}", byte)
-    }
-}
-
-impl fmt::Debug for Pattern {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Pattern::Byte(byte) => format_ascii(*byte, f),
-            Pattern::Range(a, b) => {
-                format_ascii(*a, f)?;
-                f.write_str("-")?;
-                format_ascii(*b, f)
-            },
-            Pattern::Class(class) => {
-                f.write_str("[")?;
-                for pat in class.iter() {
-                    write!(f, "{:?}", pat)?;
-                }
-                f.write_str("]")
-            },
-        }
-    }
-}
-
 impl fmt::Debug for RepetitionFlag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -433,227 +400,9 @@ impl fmt::Debug for Regex {
     }
 }
 
-impl Pattern {
-    pub fn new<I>(bytes: I) -> Self
-    where
-        I: IntoIterator<Item = u8>,
-    {
-        let mut bytes = bytes.into_iter();
-        let mut first = bytes.next().expect("Internal Error: Emtpy Pattern");
-        let mut last  = first;
-        let mut class = Vec::new();
-
-        let mut push = |first, last| {
-            if first == last {
-                class.push(Pattern::Byte(first));
-            } else {
-                class.push(Pattern::Range(first, last));
-            }
-        };
-
-        for byte in bytes {
-            if byte == last + 1 {
-                last = byte;
-
-                continue;
-            }
-
-            push(first, last);
-
-            first = byte;
-            last = byte;
-        }
-
-        // Handle last values
-        push(first, last);
-
-        if class.len() == 1 {
-            class.remove(0)
-        } else {
-            Pattern::Class(class)
-        }
-    }
-
-    pub fn bytes(&self) -> Bytes {
-        let mut bytes = Bytes {
-            buf: [0; 256],
-            len: 0,
-            index: 0,
-        };
-
-        bytes.len = self.write_bytes(&mut bytes.buf) as u8;
-
-        bytes
-    }
-
-    pub fn is_byte(&self) -> bool {
-        match self {
-            Pattern::Byte(_) => true,
-            _ => false,
-        }
-    }
-
-    pub fn weight(&self) -> usize {
-        match self {
-            Pattern::Byte(_) => 1,
-            Pattern::Range(_, _) => 2,
-            Pattern::Class(pats) => pats.iter().map(Self::weight).sum(),
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        match self {
-            Pattern::Byte(_) => 1,
-            Pattern::Range(a, b) => (*b as usize).saturating_sub(*a as usize) + 1,
-            Pattern::Class(pats) => pats.iter().map(Self::len).sum(),
-        }
-    }
-
-    pub fn intersect(&self, other: &Pattern) -> Option<Pattern> {
-        if self == other {
-            return None;
-        }
-
-        if self.contains(other) {
-            Some(other.clone())
-        } else if other.contains(self) {
-            Some(self.clone())
-        } else {
-            None
-        }
-    }
-
-    pub fn combine(&mut self, other: &Pattern) {
-        *self = Pattern::new(MergeAscending::new(&*self, other));
-    }
-
-    pub fn subtract(&mut self, other: &Pattern) {
-        *self = Pattern::new(DiffAscending::new(&*self, other));
-    }
-
-    pub fn negate(&self) -> Pattern {
-        Pattern::new(DiffAscending::new(0..=255, &*self))
-    }
-
-    pub fn contains(&self, other: &Pattern) -> bool {
-        let mut buffer = [0; 256];
-        let offset = self.write_bytes(&mut buffer);
-        let bytes = &buffer[..offset];
-
-        other.bytes().all(|byte| bytes.binary_search(&byte).is_ok())
-    }
-
-    fn write_bytes(&self, mut target: &mut [u8]) -> usize {
-        let len = self.len();
-
-        match self {
-            Pattern::Byte(b) => {
-                target[0] = *b;
-            },
-            Pattern::Range(a, b) => {
-                for (index, byte) in (*a..=*b).enumerate() {
-                    target[index] = byte;
-                }
-            }
-            Pattern::Class(class) => {
-                for pat in class.iter() {
-                    let len = pat.write_bytes(target);
-
-                    target = &mut target[len..];
-                }
-            },
-        }
-
-        len
-    }
-}
-
-/// Iterator of all the bytes within the `Pattern`
-pub struct Bytes {
-    buf: [u8; 256],
-    len: u8,
-    index: u8,
-}
-
-impl Iterator for Bytes {
-    type Item = u8;
-
-    fn next(&mut self) -> Option<u8> {
-        if self.index < self.len {
-            let byte = self.buf[self.index as usize];
-            self.index += 1;
-            Some(byte)
-        } else {
-            None
-        }
-    }
-}
-
-impl<'a> IntoIterator for &'a Pattern {
-    type Item = u8;
-    type IntoIter = Bytes;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.bytes()
-    }
-}
-
-impl PartialOrd for Pattern {
-    fn partial_cmp(&self, other: &Pattern) -> Option<Ordering> {
-        match (self, other) {
-            (&Pattern::Byte(ref byte), &Pattern::Byte(ref other)) => Some(byte.cmp(other)),
-
-            // Shorter first
-            _ => match self.len().partial_cmp(&other.len()) {
-                // Equal length != equal patterns, so let's not do that!
-                Some(Ordering::Equal) => None,
-                ordering              => ordering
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn pattern_bytes_byte() {
-        let pattern = Pattern::Byte(b'a');
-
-        assert!(pattern.bytes().eq("a".bytes()));
-    }
-
-    #[test]
-    fn pattern_bytes_range() {
-        let pattern = Pattern::Range(b'a', b'f');
-
-        assert!(pattern.bytes().eq("abcdef".bytes()));
-    }
-
-    #[test]
-    fn pattern_bytes_alternative() {
-        let pattern = Pattern::Class(vec![
-            Pattern::Byte(b'_'),
-            Pattern::Byte(b'$'),
-            Pattern::Byte(b'!'),
-        ]);
-
-        assert!(pattern.bytes().eq("_$!".bytes()));
-    }
-
-    #[test]
-    fn pattern_bytes_complex() {
-        let pattern = Pattern::Class(vec![
-            Pattern::Range(b'a', b'f'),
-            Pattern::Range(b'0', b'9'),
-            Pattern::Byte(b'_'),
-            Pattern::Byte(b'$'),
-            Pattern::Byte(b'!'),
-        ]);
-
-        assert!(pattern.bytes().eq("abcdef0123456789_$!".bytes()));
-    }
 
     fn branch(node: Node) -> Option<Branch> {
         match node {

--- a/logos-derive/src/regex.rs
+++ b/logos-derive/src/regex.rs
@@ -156,7 +156,7 @@ impl Regex {
 
     pub fn sequence(source: &str) -> Self {
         Regex {
-            patterns: source.bytes().map(|byte| Pattern::Byte(byte)).collect(),
+            patterns: source.bytes().map(Pattern::Byte).collect(),
         }
     }
 

--- a/logos-derive/src/regex.rs
+++ b/logos-derive/src/regex.rs
@@ -13,7 +13,10 @@ pub struct Regex {
 }
 
 impl<'a> Node<'a> {
-    pub fn from_sequence(source: &str, leaf: Leaf<'a>) -> Self {
+    pub fn from_sequence<Source>(source: Source, leaf: Leaf<'a>) -> Self
+    where
+        Source: AsRef<[u8]>,
+    {
         let regex = Regex::sequence(source);
 
         if regex.len() == 0 {
@@ -164,9 +167,12 @@ impl Regex {
         self.patterns().len()
     }
 
-    pub fn sequence(source: &str) -> Self {
+    pub fn sequence<Source>(source: Source) -> Self
+    where
+        Source: AsRef<[u8]>,
+    {
         Regex {
-            patterns: source.bytes().map(Pattern::Byte).collect(),
+            patterns: source.as_ref().iter().cloned().map(Pattern::Byte).collect(),
         }
     }
 

--- a/logos-derive/src/regex/pattern.rs
+++ b/logos-derive/src/regex/pattern.rs
@@ -1,0 +1,327 @@
+use std::cmp::Ordering;
+use std::fmt;
+
+use crate::util::{MergeAscending, DiffAscending};
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum Pattern {
+    Byte(u8),
+    Range(u8, u8),
+    Class(Vec<Pattern>),
+}
+
+impl Pattern {
+    pub fn new<I>(bytes: I) -> Self
+    where
+        I: IntoIterator<Item = u8>,
+    {
+        let mut bytes = bytes.into_iter();
+        let mut first = bytes.next().expect("Internal Error: Emtpy Pattern");
+        let mut last  = first;
+        let mut class = Vec::new();
+
+        let mut push = |first, last| {
+            if first == last {
+                class.push(Pattern::Byte(first));
+            } else {
+                class.push(Pattern::Range(first, last));
+            }
+        };
+
+        for byte in bytes {
+            if byte == last + 1 {
+                last = byte;
+
+                continue;
+            }
+
+            push(first, last);
+
+            first = byte;
+            last = byte;
+        }
+
+        // Handle last values
+        push(first, last);
+
+        if class.len() == 1 {
+            class.remove(0)
+        } else {
+            Pattern::Class(class)
+        }
+    }
+
+    pub fn bytes(&self) -> Bytes {
+        let mut bytes = Bytes {
+            buf: [0; 256],
+            len: 0,
+            index: 0,
+        };
+
+        bytes.len = self.write_bytes(&mut bytes.buf) as u8;
+
+        bytes
+    }
+
+    pub fn is_byte(&self) -> bool {
+        match self {
+            Pattern::Byte(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn weight(&self) -> usize {
+        match self {
+            Pattern::Byte(_) => 1,
+            Pattern::Range(_, _) => 2,
+            Pattern::Class(pats) => pats.iter().map(Self::weight).sum(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Pattern::Byte(_) => 1,
+            Pattern::Range(a, b) => (*b as usize).saturating_sub(*a as usize) + 1,
+            Pattern::Class(pats) => pats.iter().map(Self::len).sum(),
+        }
+    }
+
+    pub fn intersect(&self, other: &Pattern) -> Option<Pattern> {
+        if self == other {
+            return None;
+        }
+
+        if self.contains(other) {
+            Some(other.clone())
+        } else if other.contains(self) {
+            Some(self.clone())
+        } else {
+            None
+        }
+    }
+
+    pub fn combine(&mut self, other: &Pattern) {
+        *self = Pattern::new(MergeAscending::new(&*self, other));
+    }
+
+    pub fn subtract(&mut self, other: &Pattern) {
+        *self = Pattern::new(DiffAscending::new(&*self, other));
+    }
+
+    pub fn negate(&self) -> Pattern {
+        Pattern::new(DiffAscending::new(0..=255, &*self))
+    }
+
+    pub fn contains(&self, other: &Pattern) -> bool {
+        let mut buffer = [0; 256];
+        let offset = self.write_bytes(&mut buffer);
+        let bytes = &buffer[..offset];
+
+        other.bytes().all(|byte| bytes.binary_search(&byte).is_ok())
+    }
+
+    fn write_bytes(&self, mut target: &mut [u8]) -> usize {
+        let len = self.len();
+
+        match self {
+            Pattern::Byte(b) => {
+                target[0] = *b;
+            },
+            Pattern::Range(a, b) => {
+                for (index, byte) in (*a..=*b).enumerate() {
+                    target[index] = byte;
+                }
+            }
+            Pattern::Class(class) => {
+                for pat in class.iter() {
+                    let len = pat.write_bytes(target);
+
+                    target = &mut target[len..];
+                }
+            },
+        }
+
+        len
+    }
+}
+
+/// Iterator of all the bytes within the `Pattern`
+pub struct Bytes {
+    buf: [u8; 256],
+    len: u8,
+    index: u8,
+}
+
+impl Iterator for Bytes {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<u8> {
+        if self.index < self.len {
+            let byte = self.buf[self.index as usize];
+            self.index += 1;
+            Some(byte)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Pattern {
+    type Item = u8;
+    type IntoIter = Bytes;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.bytes()
+    }
+}
+
+impl PartialOrd for Pattern {
+    fn partial_cmp(&self, other: &Pattern) -> Option<Ordering> {
+        match (self, other) {
+            (&Pattern::Byte(ref byte), &Pattern::Byte(ref other)) => Some(byte.cmp(other)),
+
+            // Shorter first
+            _ => match self.len().partial_cmp(&other.len()) {
+                // Equal length != equal patterns, so let's not do that!
+                Some(Ordering::Equal) => None,
+                ordering              => ordering
+            }
+        }
+    }
+}
+
+impl fmt::Debug for Pattern {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Pattern::Byte(byte) => format_ascii(*byte, f),
+            Pattern::Range(a, b) => {
+                format_ascii(*a, f)?;
+                f.write_str("-")?;
+                format_ascii(*b, f)
+            },
+            Pattern::Class(class) => {
+                f.write_str("[")?;
+                for pat in class.iter() {
+                    write!(f, "{:?}", pat)?;
+                }
+                f.write_str("]")
+            },
+        }
+    }
+}
+
+fn format_ascii(byte: u8, f: &mut fmt::Formatter) -> fmt::Result {
+    if byte >= 0x20 && byte <= 127 {
+        write!(f, "{}", byte as char)
+    } else {
+        write!(f, "{:02X?}", byte)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn bytes_iter_byte() {
+        let pattern = Pattern::Byte(b'a');
+
+        assert!(pattern.bytes().eq("a".bytes()));
+    }
+
+    #[test]
+    fn bytes_iter_range() {
+        let pattern = Pattern::Range(b'a', b'f');
+
+        assert!(pattern.bytes().eq("abcdef".bytes()));
+    }
+
+    #[test]
+    fn bytes_iter_alternative() {
+        let pattern = Pattern::Class(vec![
+            Pattern::Byte(b'!'),
+            Pattern::Byte(b'$'),
+            Pattern::Byte(b'_'),
+        ]);
+
+        assert!(pattern.bytes().eq("!$_".bytes()));
+    }
+
+    #[test]
+    fn bytes_iter_complex() {
+        let pattern = Pattern::Class(vec![
+            Pattern::Byte(b'!'),
+            Pattern::Byte(b'$'),
+            Pattern::Range(b'0', b'9'),
+            Pattern::Byte(b'_'),
+            Pattern::Range(b'a', b'f'),
+        ]);
+
+        assert!(pattern.bytes().eq("!$0123456789_abcdef".bytes()));
+    }
+
+    #[test]
+    fn from_iterator() {
+        let pattern = Pattern::new("!$0123456789_abcdef".bytes());
+
+        let expected = Pattern::Class(vec![
+            Pattern::Byte(b'!'),
+            Pattern::Byte(b'$'),
+            Pattern::Range(b'0', b'9'),
+            Pattern::Byte(b'_'),
+            Pattern::Range(b'a', b'f'),
+        ]);
+
+        assert_eq!(pattern, expected);
+    }
+
+
+    #[test]
+    fn combine() {
+        let mut pattern = Pattern::Byte(0);
+
+        pattern.combine(&Pattern::Range(b'A', b'Z'));
+        pattern.combine(&Pattern::Range(b'0', b'9'));
+
+        let expected = Pattern::Class(vec![
+            Pattern::Byte(0),
+            Pattern::Range(b'0', b'9'),
+            Pattern::Range(b'A', b'Z'),
+        ]);
+
+        assert_eq!(pattern, expected);
+    }
+
+    #[test]
+    fn subtract() {
+        let mut pattern = Pattern::Range(b'0', b'9');
+
+        pattern.subtract(&Pattern::Range(b'1', b'3'));
+        pattern.subtract(&Pattern::Byte(b'7'));
+
+        let expected = Pattern::Class(vec![
+            Pattern::Byte(b'0'),
+            Pattern::Range(b'4', b'6'),
+            Pattern::Range(b'8', b'9'),
+        ]);
+
+        assert_eq!(pattern, expected);
+    }
+
+    #[test]
+    fn overlapping() {
+        let mut pattern = Pattern::Class(vec![
+            Pattern::Range(b'0', b'9'),
+            Pattern::Range(b'A', b'Z'),
+        ]);
+
+        pattern.subtract(&Pattern::Range(b'8', b'E'));
+
+        let expected = Pattern::Class(vec![
+            Pattern::Range(b'0', b'7'),
+            Pattern::Range(b'F', b'Z'),
+        ]);
+
+        assert_eq!(pattern, expected);
+    }
+}

--- a/logos-derive/src/tree.rs
+++ b/logos-derive/src/tree.rs
@@ -468,6 +468,8 @@ impl<'a> Fork<'a> {
     }
 
     pub fn pack(&mut self) {
+        self.collapse();
+
         if let Some(then) = &mut self.then {
             then.pack();
         }

--- a/logos-derive/src/tree.rs
+++ b/logos-derive/src/tree.rs
@@ -318,8 +318,8 @@ mod tests {
 
         let expected = Node::Fork(
             Fork::new(Plain)
-                .arm(Branch::new(Pattern::from(&b"ace"[..])).then(&token))
-                .arm(Branch::new(Pattern::from(&b"bdf"[..])))
+                .arm(Branch::new(Pattern::new("ace".bytes())).then(&token))
+                .arm(Branch::new(Pattern::new("bdf".bytes())))
         );
 
         assert_eq!(node, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", node, expected);
@@ -422,10 +422,10 @@ mod tests {
                             .arm(
                                 Branch::new(&[
                                     Pattern::Byte(b'x'),
-                                    Pattern::from(&b"0123456789abcdef"[..]),
+                                    Pattern::new("0123456789abcdef".bytes()),
                                 ][..]).then(
                                     Fork::new(Repeat)
-                                        .arm(Branch::new(Pattern::from(&b"0123456789abcdef"[..])))
+                                        .arm(Branch::new(Pattern::new("0123456789abcdef".bytes())))
                                         .then(&hex)
                                 )
                             )
@@ -475,11 +475,11 @@ mod tests {
                 .arm(
                     Branch::new("a")
                         .then(Fork::new(Repeat).arm(Branch::new("a")).then(&a))
-                        .fallback(Fork::new(Repeat).arm(Branch::new(Pattern::from(&b"ab"[..]))).then(&ab))
+                        .fallback(Fork::new(Repeat).arm(Branch::new(Pattern::new("ab".bytes()))).then(&ab))
                 )
                 .arm(
                     Branch::new("b")
-                        .then(Fork::new(Repeat).arm(Branch::new(Pattern::from(&b"ab"[..]))).then(&ab))
+                        .then(Fork::new(Repeat).arm(Branch::new(Pattern::new("ab".bytes()))).then(&ab))
                 );
 
         assert_eq!(fork, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", fork, expected);

--- a/logos-derive/src/tree.rs
+++ b/logos-derive/src/tree.rs
@@ -1,774 +1,17 @@
-use std::{mem, fmt};
-use std::cmp::Ordering;
-use rustc_hash::FxHashMap as HashMap;
-
-use crate::handlers::Fallback;
-use crate::regex::{Regex, Pattern, RepetitionFlag};
-
-pub type Token<'a> = &'a ::syn::Ident;
-pub type Callback = ::syn::Ident;
-
-#[derive(Clone, Default, PartialEq, Eq, Hash)]
-pub struct Branch<'a> {
-    pub regex: Regex,
-    pub then: Option<Box<Node<'a>>>,
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Leaf<'a> {
-    pub token: Token<'a>,
-    pub callback: Option<Callback>,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum ForkKind {
-    Plain  = 0,
-    Maybe  = 1,
-    Repeat = 2,
-}
-
-impl Default for ForkKind {
-    fn default() -> Self {
-        ForkKind::Plain
-    }
-}
-
-#[derive(Clone, Default, PartialEq, Eq, Hash)]
-pub struct Fork<'a> {
-    pub kind: ForkKind,
-    pub arms: Vec<Branch<'a>>,
-    pub then: Option<Box<Node<'a>>>,
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub enum Node<'a> {
-    Branch(Branch<'a>),
-    Fork(Fork<'a>),
-    Leaf(Leaf<'a>),
-}
-
-impl<'a> fmt::Debug for Node<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Node::Branch(branch) => branch.fmt(f),
-            Node::Fork(fork) => fork.fmt(f),
-            Node::Leaf(leaf) => write!(f, "TOKEN \"{:?}\"", leaf),
-        }
-    }
-}
-
-impl<'a> fmt::Debug for Branch<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.regex.fmt(f)?;
-
-        if let Some(ref then) = self.then {
-            f.write_str(" -> ")?;
-            then.fmt(f)?;
-        }
-
-        Ok(())
-    }
-}
-
-impl<'a> fmt::Debug for Leaf<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.token)?;
-
-        if let Some(ref callback) = self.callback {
-            write!(f, " ({})", callback)?;
-        }
-
-        Ok(())
-    }
-}
-
-impl fmt::Debug for ForkKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ForkKind::Plain => Ok(()),
-            ForkKind::Maybe => f.write_str("MAYBE "),
-            ForkKind::Repeat => f.write_str("REPEAT "),
-        }
-    }
-}
-
-impl<'a> fmt::Debug for Fork<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.kind.fmt(f)?;
-
-        if self.arms.len() == 1 && self.arms[0].then.is_none() {
-            f.write_str("[")?;
-            self.arms[0].fmt(f)?;
-            f.write_str("]")?;
-        } else {
-            f.debug_list().entries(self.arms.iter()).finish()?;
-        }
-
-        if let Some(ref then) = self.then {
-            f.write_str(" -> ")?;
-            then.fmt(f)?;
-        }
-
-        Ok(())
-    }
-}
-
-impl<'a> From<Token<'a>> for Leaf<'a> {
-    fn from(token: Token<'a>) -> Self {
-        Leaf {
-            token,
-            callback: None,
-        }
-    }
-}
-
-impl<'a> From<Token<'a>> for Node<'a> {
-    fn from(token: Token<'a>) -> Self {
-        Node::Leaf(token.into())
-    }
-}
-
-impl<'a> From<Leaf<'a>> for Node<'a> {
-    fn from(leaf: Leaf<'a>) -> Self {
-        Node::Leaf(leaf)
-    }
-}
-
-impl<'a> From<Branch<'a>> for Node<'a> {
-    fn from(branch: Branch<'a>) -> Self {
-        if branch.regex.len() == 0 {
-            *branch.then.expect("Cannot convert an empty branch to a Node!")
-        } else {
-            Node::Branch(branch)
-        }
-    }
-}
-
-impl<'a> From<Fork<'a>> for Node<'a> {
-    fn from(fork: Fork<'a>) -> Self {
-        if fork.arms.len() == 0 {
-            if let Some(then) = fork.then {
-                return *then;
-            }
-        }
-
-        Node::Fork(fork)
-    }
-}
-
-impl<'a> From<Fork<'a>> for Box<Node<'a>> {
-    fn from(fork: Fork<'a>) -> Self {
-        Node::from(fork).boxed()
-    }
-}
-
-impl<'a> Leaf<'a> {
-    fn take(&mut self) -> Leaf<'a> {
-        Leaf {
-            token: self.token,
-            callback: self.callback.take(),
-        }
-    }
-}
-
-impl<'a> Branch<'a> {
-    pub fn new(regex: Regex) -> Self {
-        Branch {
-            regex,
-            then: None,
-        }
-    }
-
-    pub fn compare(&self, other: &Branch<'a>) -> Ordering {
-        other.regex.first().partial_cmp(self.regex.first()).unwrap_or_else(|| Ordering::Greater)
-    }
-
-    fn chain(&mut self, then: &Node<'a>) {
-        match self.then {
-            Some(ref mut node) => node.chain(then),
-            None => {
-                self.then = Some(then.clone().boxed());
-            },
-        }
-    }
-
-    pub fn insert_then(&mut self, other: Option<Box<Node<'a>>>) {
-        match self.then {
-            Some(ref mut node) => {
-                match other {
-                    Some(other) => node.insert(*other),
-                    None => node.make_maybe_fork(),
-                }
-            }
-            ref mut then => *then = other,
-        }
-    }
-
-    fn to_node(self) -> Option<Node<'a>> {
-        if self.regex.len() == 0 {
-            self.then.map(|node| *node)
-        } else {
-            Some(Node::Branch(self))
-        }
-    }
-
-    fn is_finite(&self) -> bool {
-        match self.then {
-            Some(ref node) => match **node {
-                Node::Fork(ref fork) => fork.kind == ForkKind::Plain,
-                _ => true,
-            },
-            None => false,
-        }
-    }
-
-    pub fn matches(&self, pattern: &Pattern) -> bool {
-        self.regex
-            .patterns()
-            .iter()
-            .all(|pat| pattern.contains(pat))
-    }
-
-    pub fn min_bytes(&self) -> usize {
-        self.regex.len() + self.then.as_ref().map(|node| node.min_bytes()).unwrap_or(0)
-    }
-
-    pub fn pack(&mut self) {
-        if let Some(ref mut then) = self.then {
-            then.pack();
-
-            match &mut **then {
-                Node::Branch(branch) => {
-                    if let Some(next) = &mut branch.then {
-                        next.pack();
-                    }
-
-                    self.regex.extend(branch.regex.patterns());
-                    self.then = branch.then.take();
-                },
-                Node::Fork(fork) => fork.pack(),
-                Node::Leaf(_) => {},
-            }
-        }
-    }
-}
-
-impl<'a> Fork<'a> {
-    pub fn insert(&mut self, then: Node<'a>) {
-        match then {
-            Node::Branch(branch) => {
-                // If possible, we unwind repeat forks and collapse maybe forks.
-                self.unwind();
-                self.collapse();
-
-                self.insert_branch(branch);
-            },
-            Node::Leaf(leaf) => {
-                if self.then.is_none() {
-                    assert!(
-                        self.kind == ForkKind::Plain,
-                        "Internal Error: Invalid fork construction: {:#?}", self
-                    );
-
-                    self.kind = ForkKind::Maybe;
-                    self.then = Some(Node::Leaf(leaf).boxed());
-                } else {
-                    self.unwind();
-                    self.collapse();
-
-                    assert!(
-                        self.kind != ForkKind::Plain,
-                        "Internal Error: Invalid fork construction: {:#?}", self
-                    );
-
-                    self.kind = ForkKind::Maybe;
-                    self.then = Some(Node::Leaf(leaf).boxed());
-                }
-
-                // FIXME: look up through all tokens produced by `self.then`,
-                //        if they point at a token different from `token`,
-                //        panic with an error about conflicting definitions!
-            },
-            Node::Fork(mut other) => {
-                if self.kind == other.kind && self.arms == other.arms {
-                    self.insert_then(other.then.take());
-
-                    return;
-                }
-
-                // If possible, we unwind repeat forks and collapse maybe forks.
-                self.unwind();
-                self.collapse();
-                other.unwind();
-                other.collapse();
-
-                if other.kind > self.kind {
-                    self.kind = other.kind;
-                }
-
-                self.insert_then(other.then.take());
-
-                for branch in other.arms.into_iter() {
-                    self.insert_branch(branch);
-                }
-            }
-        }
-    }
-
-    pub fn insert_branch(&mut self, mut branch: Branch<'a>) {
-        if branch.regex.len() == 0 {
-            return self.insert_then(branch.then);
-        }
-
-        // Looking for intersection prefixes, that is: A ≠ B & (A ⊂ B | B ⊂ A)
-        for other in self.arms.iter_mut().filter(|arm| arm.is_finite()) {
-            if let Some(prefix) = branch.regex.common_prefix(&other.regex) {
-                let mut intersection = Branch::new(Regex::from(prefix));
-
-                let mut a = branch.clone();
-                let mut b = other.clone();
-
-                a.regex.unshift();
-                b.regex.unshift();
-
-                intersection.insert_then(a.to_node().map(Box::new));
-                intersection.insert_then(b.to_node().map(Box::new));
-
-                if intersection.regex.first() == branch.regex.first() {
-                    branch = intersection;
-                } else {
-                    mem::swap(other, &mut intersection);
-                }
-            }
-        }
-
-        // Look for a branch that matches the same prefix
-        for other in self.arms.iter_mut() {
-            // We got a match!
-            if let Some(regex) = branch.regex.match_split(&mut other.regex) {
-                let old = mem::replace(other, Branch {
-                    regex,
-                    then: None,
-                });
-
-                let a = branch.to_node().map(Box::new);
-                let b = old.to_node().map(Box::new);
-
-                let maybe_fork = a.is_none() || b.is_none();
-
-                other.insert_then(a);
-                other.insert_then(b);
-
-                if maybe_fork {
-                    if let Some(ref mut then) = other.then {
-                        then.make_maybe_fork();
-                    }
-                }
-
-                return;
-            }
-        }
-
-        self.sorted_insert_arm(branch);
-    }
-
-    fn sorted_insert_arm(&mut self, branch: Branch<'a>) {
-        // Sort arms of the fork, simple bytes in alphabetical order first, patterns last
-        match self.arms.binary_search_by(|other| branch.compare(other)) {
-            Ok(index) => {
-                self.arms[index].insert_then(branch.to_node().map(Box::new));
-            },
-            Err(index) => {
-                self.arms.insert(index, branch.into());
-            },
-        }
-    }
-
-    pub fn insert_then(&mut self, other: Option<Box<Node<'a>>>) {
-        match self.then {
-            Some(ref mut node) => {
-                match other {
-                    Some(other) => node.insert(*other),
-                    None => node.make_maybe_fork(),
-                }
-            }
-            None => {
-                if other.is_some() {
-                    assert!(
-                        self.kind != ForkKind::Repeat,
-                        "Internal Error: Invalid fork construction"
-                    );
-
-                    self.kind = ForkKind::Maybe;
-                    self.then = other;
-                }
-            },
-        }
-    }
-
-    /// Unwinds a Repeat fork into a Maybe fork
-    pub fn unwind(&mut self) {
-        if self.kind != ForkKind::Repeat {
-            return;
-        }
-
-        let repeat = Node::from(self.clone());
-
-        for branch in self.arms.iter_mut() {
-            branch.chain(&repeat);
-        }
-
-        if let Some(mut then) = self.then.take() {
-            match *then {
-                Node::Fork(ref mut fork) if fork.kind == ForkKind::Plain => {
-                    for branch in fork.arms.drain(..) {
-                        self.insert_branch(branch);
-                    }
-
-                    return self.kind = ForkKind::Plain;
-                },
-                Node::Branch(ref mut branch) => {
-                    self.insert_branch(branch.clone());
-
-                    return self.kind = ForkKind::Plain;
-                },
-                _ => self.then = Some(then),
-            }
-        }
-
-        self.kind = ForkKind::Maybe;
-    }
-
-    // Attempts to collapse a Maybe fork into a Plain fork.
-    // If `then` on this fork is a `Token`, or if it isn't
-    // set, then it will remain a Maybe fork.
-    pub fn collapse(&mut self) {
-        if self.kind != ForkKind::Maybe {
-            return;
-        }
-
-        let then = match self.then.take() {
-            None => return,
-            Some(node) => node,
-        };
-
-        for branch in self.arms.iter_mut() {
-            branch.chain(&*then);
-        }
-
-        if then.is_token() {
-            self.then = Some(then);
-        } else {
-            self.kind = ForkKind::Plain;
-            self.insert(*then);
-        }
-    }
-
-    fn chain(&mut self, then: &Node<'a>) {
-        if self.kind == ForkKind::Plain {
-            for branch in self.arms.iter_mut() {
-                branch.chain(then)
-            }
-        } else {
-            match self.then {
-                Some(ref mut node) => node.chain(then),
-                None => {
-                    self.then = Some(then.clone().boxed());
-                },
-            }
-        }
-    }
-
-    /// Minimum amount of bytes that will satisfy this Fork
-    pub fn min_bytes(&self) -> usize {
-        self.arms
-            .iter()
-            .map(|arm| arm.min_bytes())
-            .min()
-            .unwrap_or(0)
-    }
-
-    pub fn pack(&mut self) {
-        self.collapse();
-
-        if let Some(then) = &mut self.then {
-            then.pack();
-        }
-
-        self.arms.iter_mut().for_each(Branch::pack);
-
-        if self.arms.len() > 1 {
-            let mut scan: HashMap<&Option<Box<Node>>, usize> = HashMap::default();
-            let mut remove = Vec::new();
-
-            for (index, arm) in self.arms.iter_mut().enumerate() {
-                if arm.regex.len() > 1 {
-                    continue;
-                }
-
-                let retain = *scan.entry(&arm.then).or_insert(index);
-
-                if retain != index {
-                    remove.push((retain, index, arm.regex.unshift()));
-                }
-            }
-
-            for (retain, index, pattern) in remove.into_iter().rev() {
-                self.arms[retain].regex.first_mut().combine(pattern);
-                self.arms.remove(index);
-            }
-        }
-
-        if self.kind == ForkKind::Maybe && self.arms.len() == 1 && self.arms[0].then == self.then {
-            self.arms[0].then = None;
-        }
-    }
-}
-
-impl<'a> Node<'a> {
-    pub fn new(regex: Regex, leaf: Leaf<'a>) -> Self {
-        if regex.len() == 0 {
-            Node::Leaf(leaf)
-        } else {
-            Node::Branch(Branch {
-                regex,
-                then: Some(Node::from(leaf).boxed()),
-            })
-        }
-    }
-
-    pub fn is_leaf(&self) -> bool {
-        match self {
-            Node::Leaf(_) => true,
-            _ => false,
-        }
-    }
-
-    fn to_mut_fork(&mut self) -> &mut Fork<'a> {
-        let fork = match self {
-            Node::Fork(fork) => return fork,
-            Node::Branch(ref mut branch) => {
-                let branch = mem::replace(branch, Branch {
-                    regex: Regex::default(),
-                    then: None,
-                });
-
-                Fork {
-                    kind: ForkKind::Plain,
-                    arms: vec![branch],
-                    then: None,
-                }
-            },
-            Node::Leaf(leaf) => {
-                Fork {
-                    kind: ForkKind::Maybe,
-                    arms: vec![],
-                    then: Some(Node::Leaf(leaf.take()).boxed()),
-                }
-            }
-        };
-
-        mem::replace(self, Node::Fork(fork));
-
-        if let Node::Fork(fork) = self {
-            fork
-        } else {
-            unreachable!()
-        }
-    }
-
-    fn make_maybe_fork(&mut self) {
-        let fork = match self {
-            Node::Fork(fork) => {
-                assert!(fork.kind != ForkKind::Repeat);
-
-                return fork.kind = ForkKind::Maybe;
-            },
-            Node::Branch(ref mut branch) => {
-                let branch = mem::replace(branch, Branch {
-                    regex: Regex::default(),
-                    then: None,
-                });
-
-                Fork {
-                    kind: ForkKind::Maybe,
-                    arms: vec![branch],
-                    then: None,
-                }
-            },
-            Node::Leaf(_) => return,
-        };
-
-        mem::replace(self, Node::Fork(fork));
-    }
-
-    pub fn insert(&mut self, then: Node<'a>) {
-        if self.is_leaf() && then.is_leaf() {
-            return;
-        }
-
-        self.to_mut_fork().insert(then);
-
-        let then = match self {
-            Node::Fork(fork) if fork.arms.len() == 0 => {
-                fork.then.take()
-            },
-            _ => None
-        };
-
-        if let Some(then) = then {
-            mem::replace(self, *then);
-        }
-    }
-
-    pub fn make_repeat(&mut self, flag: RepetitionFlag) {
-        use self::RepetitionFlag::*;
-
-        if let Node::Branch(branch) = self {
-            if flag == OneOrMore {
-                let mut next = Node::from(branch.clone());
-
-                next.to_mut_fork().kind = ForkKind::Repeat;
-
-                return branch.then = Some(next.boxed());
-            }
-        }
-
-        let fork = self.to_mut_fork();
-
-        match flag {
-            ZeroOrOne => fork.kind = ForkKind::Maybe,
-            ZeroOrMore => fork.kind = ForkKind::Repeat,
-            OneOrMore => {
-                let mut next: Fork = fork.clone();
-
-                next.kind = ForkKind::Repeat;
-
-                fork.insert_then(Some(next.into()));
-            }
-        }
-    }
-
-    /// Checks if all branches in the node match a specific pattern
-    pub fn matches(&self, pattern: &Pattern) -> bool {
-        match self {
-            Node::Branch(branch) => branch.matches(pattern),
-            Node::Fork(fork) => {
-                fork.arms.iter().all(|arm| arm.matches(pattern))
-                    && fork.then.as_ref().map(|then| then.matches(pattern)).unwrap_or(true)
-            },
-            Node::Leaf(_) => true,
-        }
-    }
-
-    pub fn fallback(&self) -> Option<Fallback<'a>> {
-        match self {
-            Node::Fork(fork) => {
-                let arm = &fork.arms[0];
-                let leaf = match &fork.then {
-                    Some(node) => match **node {
-                        Node::Leaf(ref leaf) => leaf,
-                        _ => return None,
-                    },
-                    _ => return None,
-                };
-
-                if fork.kind == ForkKind::Repeat
-                    && fork.arms.len() == 1
-                    && arm.regex.len() == 1
-                    && arm.then.is_none()
-                {
-                    Some(Fallback {
-                        boundary: arm.regex.first().clone(),
-                        leaf: leaf.clone()
-                    })
-                } else {
-                    None
-                }
-            },
-            _ => None
-        }
-    }
-
-    /// Get all tokens in this tree
-    pub fn get_tokens(&self, vec: &mut Vec<Token<'a>>) {
-        fn insert<'a>(vec: &mut Vec<Token<'a>>, token: Token<'a>) {
-            if let Err(index) = vec.binary_search(&token) {
-                vec.insert(index, token);
-            }
-        }
-
-        match self {
-            Node::Leaf(leaf) => insert(vec, leaf.token),
-            Node::Branch(branch) => {
-                if let Some(ref then) = branch.then {
-                    then.get_tokens(vec);
-                }
-            },
-            Node::Fork(fork) => {
-                for branch in fork.arms.iter() {
-                    if let Some(ref then) = branch.then {
-                        then.get_tokens(vec);
-                    }
-                }
-                if let Some(ref then) = fork.then {
-                    then.get_tokens(vec);
-                }
-            }
-        }
-    }
-
-    pub fn chain(&mut self, then: &Node<'a>) {
-        match self {
-            Node::Branch(branch) => branch.chain(then),
-            Node::Fork(fork) => fork.chain(then),
-            Node::Leaf(_) => {},
-        }
-    }
-
-    fn is_token(&self) -> bool {
-        match self {
-            Node::Leaf(_) => true,
-            _ => false,
-        }
-    }
-
-    pub fn boxed(self) -> Box<Self> {
-        Box::new(self)
-    }
-
-    pub fn min_bytes(&self) -> usize {
-        match self {
-            Node::Fork(fork) if fork.kind == ForkKind::Plain => fork.min_bytes(),
-            Node::Fork(_) => 0,
-            Node::Branch(branch) => branch.min_bytes(),
-            Node::Leaf(_) => 0,
-        }
-    }
-
-    pub fn pack(&mut self) {
-        match self {
-            Node::Fork(fork) => {
-                fork.pack();
-
-                if fork.kind == ForkKind::Plain
-                    && fork.arms.len() == 1
-                    && (fork.then.is_none() || fork.arms[0].then.is_none())
-                {
-                    let mut branch = fork.arms.remove(0);
-                    branch.then = branch.then.or(fork.then.take());
-
-                    *self = Node::Branch(branch);
-                }
-            },
-            Node::Branch(branch) => branch.pack(),
-            Node::Leaf(_) => {}
-        }
-    }
-}
+mod node;
+mod leaf;
+mod fork;
+mod branch;
+
+pub use self::node::Node;
+pub use self::fork::ForkKind::*;
+pub use self::fork::{Fork, ForkKind};
+pub use self::leaf::{Leaf, Token};
+pub use self::branch::Branch;
 
 #[cfg(test)]
 mod tests {
+    use crate::regex::Pattern;
     use super::*;
     use syn::Ident;
 
@@ -778,27 +21,16 @@ mod tests {
         Ident::new(mock, Span::call_site())
     }
 
-    fn branch<'a>(regex: &str, leaf: Leaf<'a>) -> Branch<'a> {
-        Branch {
-            regex: Regex::sequence(regex),
-            then: Some(Node::Leaf(leaf).boxed()),
-        }
-    }
-
     #[test]
     fn branch_to_node() {
-        let regex = Regex::sequence("abc");
-        let branch = Branch::new(regex.clone());
+        let branch = Branch::new("abc");
 
-        assert_eq!(branch.to_node(), Some(Node::Branch(Branch {
-            regex: regex,
-            then: None
-        })));
+        assert_eq!(branch.to_node(), Some(Node::Branch(Branch::new("abc"))));
     }
 
     #[test]
     fn empty_branch_to_node() {
-        let branch = Branch::new(Regex::default());
+        let branch = Branch::default();
 
         assert_eq!(branch.to_node(), None);
     }
@@ -807,10 +39,7 @@ mod tests {
     fn empty_branch_with_then_to_node() {
         let token = token("mock");
 
-        let branch = Branch {
-            regex: Regex::default(),
-            then: Some(Node::Leaf(Leaf::from(&token)).boxed()),
-        };
+        let branch = Branch::default().then(&token);
 
         assert_eq!(branch.to_node(), Some(Node::Leaf(Leaf::from(&token))));
     }
@@ -820,19 +49,15 @@ mod tests {
         let token_a = token("ABC");
         let token_b = token("DEF");
 
-        let branch_a = branch("abc", Leaf::from(&token_a));
-        let branch_b = branch("def", Leaf::from(&token_b));
+        let mut parent = Branch::new("abc").then(&token_a).to_node().unwrap();
 
-        let mut parent = branch("abc", Leaf::from(&token_a)).to_node().unwrap();
-        let child = branch("def", Leaf::from(&token_b)).to_node().unwrap();
+        parent.insert(Branch::new("def").then(&token_b));
 
-        parent.insert(child);
-
-        assert_eq!(parent, Node::Fork(Fork {
-            kind: ForkKind::Plain,
-            arms: vec![branch_a, branch_b],
-            then: None,
-        }));
+        assert_eq!(parent, Node::Fork(
+            Fork::new(Plain)
+                .arm(Branch::new("abc").then(&token_a))
+                .arm(Branch::new("def").then(&token_b))
+        ));
     }
 
     #[test]
@@ -840,16 +65,15 @@ mod tests {
         let token_a = token("ABC");
         let token_b = token("DEF");
 
-        let mut parent = branch("abc", Leaf::from(&token_a)).to_node().unwrap();
-        let child = Node::Leaf(Leaf::from(&token_b));
+        let mut parent = Branch::new("abc").then(&token_a).to_node().unwrap();
 
-        parent.insert(child);
+        parent.insert(Leaf::from(&token_b));
 
-        assert_eq!(parent, Node::Fork(Fork {
-            kind: ForkKind::Maybe,
-            arms: vec![branch("abc", Leaf::from(&token_a))],
-            then: Some(Node::Leaf(Leaf::from(&token_b)).boxed()),
-        }));
+        assert_eq!(parent, Node::Fork(
+            Fork::new(Maybe)
+                .arm(Branch::new("abc").then(&token_a))
+                .then(&token_b)
+        ));
     }
 
     #[test]
@@ -858,15 +82,14 @@ mod tests {
         let token_b = token("DEF");
 
         let mut parent = Node::Leaf(Leaf::from(&token_a));
-        let child = branch("xyz", Leaf::from(&token_b)).to_node().unwrap();
 
-        parent.insert(child);
+        parent.insert(Branch::new("xyz").then(&token_b));
 
-        assert_eq!(parent, Node::Fork(Fork {
-            kind: ForkKind::Maybe,
-            arms: vec![branch("xyz", Leaf::from(&token_b))],
-            then: Some(Node::Leaf(Leaf::from(&token_a)).boxed()),
-        }));
+        assert_eq!(parent, Node::Fork(
+            Fork::new(Maybe)
+                .arm(Branch::new("xyz").then(&token_b))
+                .then(&token_a)
+        ));
     }
 
     #[test]
@@ -874,28 +97,21 @@ mod tests {
         let token_a = token("ABC");
         let token_b = token("DEF");
 
-        let mut parent = Node::Fork(Fork {
-            kind: ForkKind::Plain,
-            arms: vec![branch("abc", Leaf::from(&token_a))],
-            then: None,
-        });
+        let mut parent = Node::Fork(
+            Fork::new(Plain)
+                .arm(Branch::new("abc").then(&token_a))
+        );
 
-        let child = Node::Fork(Fork {
-            kind: ForkKind::Plain,
-            arms: vec![branch("def", Leaf::from(&token_b))],
-            then: None,
-        });
+        parent.insert(
+            Fork::new(Plain)
+                .arm(Branch::new("def").then(&token_b))
+        );
 
-        parent.insert(child);
-
-        assert_eq!(parent, Node::Fork(Fork {
-            kind: ForkKind::Plain,
-            arms: vec![
-                branch("abc", Leaf::from(&token_a)),
-                branch("def", Leaf::from(&token_b)),
-            ],
-            then: None,
-        }));
+        assert_eq!(parent, Node::Fork(
+            Fork::new(Plain)
+                .arm(Branch::new("abc").then(&token_a))
+                .arm(Branch::new("def").then(&token_b))
+        ));
     }
 
     #[test]
@@ -904,28 +120,23 @@ mod tests {
         let token_b = token("DEF");
         let token_x = token("XYZ");
 
-        let mut parent = Node::Fork(Fork {
-            kind: ForkKind::Plain,
-            arms: vec![branch("abc", Leaf::from(&token_a))],
-            then: None,
-        });
+        let mut parent = Node::Fork(
+            Fork::new(Plain)
+                .arm(Branch::new("abc").then(&token_a))
+        );
 
-        let child = Node::Fork(Fork {
-            kind: ForkKind::Maybe,
-            arms: vec![branch("def", Leaf::from(&token_b))],
-            then: Some(Node::Leaf(Leaf::from(&token_x)).boxed()),
-        });
+        parent.insert(
+            Fork::new(Maybe)
+                .arm(Branch::new("def").then(&token_b))
+                .then(&token_x)
+        );
 
-        parent.insert(child);
-
-        assert_eq!(parent, Node::Fork(Fork {
-            kind: ForkKind::Maybe,
-            arms: vec![
-                branch("abc", Leaf::from(&token_a)),
-                branch("def", Leaf::from(&token_b)),
-            ],
-            then: Some(Node::Leaf(Leaf::from(&token_x)).boxed()),
-        }));
+        assert_eq!(parent, Node::Fork(
+            Fork::new(Maybe)
+                .arm(Branch::new("abc").then(&token_a))
+                .arm(Branch::new("def").then(&token_b))
+                .then(&token_x)
+        ));
     }
 
     #[test]
@@ -934,73 +145,61 @@ mod tests {
         let token_b = token("DEF");
         let token_x = token("XYZ");
 
-        let mut parent = Node::Fork(Fork {
-            kind: ForkKind::Maybe,
-            arms: vec![branch("abc", Leaf::from(&token_a))],
-            then: Some(Node::Leaf(Leaf::from(&token_x)).boxed()),
-        });
+        let mut parent = Node::Fork(
+            Fork::new(Maybe)
+                .arm(Branch::new("abc").then(&token_a))
+                .then(&token_x)
+        );
 
-        let child = Node::Fork(Fork {
-            kind: ForkKind::Plain,
-            arms: vec![branch("def", Leaf::from(&token_b))],
-            then: None,
-        });
+        parent.insert(
+            Fork::new(Plain)
+                .arm(Branch::new("def").then(&token_b))
+        );
 
-        parent.insert(child);
-
-        assert_eq!(parent, Node::Fork(Fork {
-            kind: ForkKind::Maybe,
-            arms: vec![
-                branch("abc", Leaf::from(&token_a)),
-                branch("def", Leaf::from(&token_b)),
-            ],
-            then: Some(Node::Leaf(Leaf::from(&token_x)).boxed()),
-        }));
+        assert_eq!(parent, Node::Fork(
+            Fork::new(Maybe)
+                .arm(Branch::new("abc").then(&token_a))
+                .arm(Branch::new("def").then(&token_b))
+                .then(&token_x)
+        ));
     }
 
     #[test]
     fn collapsing_a_fork() {
         let token_a = token("ABC");
 
-        let mut fork = Fork {
-            kind: ForkKind::Maybe,
-            arms: vec![Branch::new(Regex::sequence("abc"))],
-            then: Some(Node::Leaf(Leaf::from(&token_a)).boxed()),
-        };
+        let mut fork =
+            Fork::new(Maybe)
+                .arm(Branch::new("abc"))
+                .then(&token_a);
 
-        let expected = Fork {
-            kind: ForkKind::Maybe,
-            arms: vec![branch("abc", Leaf::from(&token_a))],
-            then: Some(Node::Leaf(Leaf::from(&token_a)).boxed()),
-        };
+        let expected =
+            Fork::new(Maybe)
+                .arm(Branch::new("abc").then(&token_a))
+                .then(&token_a);
 
         fork.collapse();
 
-        assert!(fork == expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", fork, expected);
+        assert_eq!(fork, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", fork, expected);
     }
 
     #[test]
     fn unwinding_a_fork() {
         let token_a = token("ABC");
 
-        let mut fork = Fork {
-            kind: ForkKind::Repeat,
-            arms: vec![Branch::new(Regex::sequence("abc"))],
-            then: Some(Node::Leaf(Leaf::from(&token_a)).boxed()),
-        };
+        let mut fork =
+            Fork::new(Repeat)
+                .arm(Branch::new("abc"))
+                .then(&token_a);
 
-        let expected = Fork {
-            kind: ForkKind::Maybe,
-            arms: vec![Branch {
-                regex: Regex::sequence("abc"),
-                then: Some(Node::Fork(fork.clone()).boxed()),
-            }],
-            then: Some(Node::Leaf(Leaf::from(&token_a)).boxed()),
-        };
+        let expected =
+            Fork::new(Maybe)
+                .arm(Branch::new("abc").then(fork.clone()))
+                .then(&token_a);
 
         fork.unwind();
 
-        assert!(fork == expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", fork, expected);
+        assert_eq!(fork, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", fork, expected);
     }
 
     #[test]
@@ -1008,33 +207,29 @@ mod tests {
         let token_a = token("ABC");
         let token_b = token("DEF");
 
-        let mut parent = Node::Fork(Fork {
-            kind: ForkKind::Plain,
-            arms: vec![branch("abc", Leaf::from(&token_a))],
-            then: None,
-        });
+        let mut parent = Node::Fork(
+            Fork::new(Plain)
+                .arm(Branch::new("abc").then(&token_a))
+        );
 
-        let child = Node::Fork(Fork {
-            kind: ForkKind::Repeat,
-            arms: vec![Branch::new(Regex::sequence("def"))],
-            then: Some(Node::Leaf(Leaf::from(&token_b)).boxed()),
-        });
+        parent.insert(
+            Fork::new(Repeat)
+                .arm(Branch::new("def"))
+                .then(&token_b)
+        );
 
-        let expected = Node::Fork(Fork {
-            kind: ForkKind::Maybe,
-            arms: vec![
-                branch("abc", Leaf::from(&token_a)),
-                Branch {
-                    regex: Regex::sequence("def"),
-                    then: Some(child.clone().boxed()),
-                }
-            ],
-            then: Some(Node::Leaf(Leaf::from(&token_b)).boxed()),
-        });
+        let expected = Node::Fork(
+            Fork::new(Maybe)
+                .arm(Branch::new("abc").then(&token_a))
+                .arm(Branch::new("def").then(
+                    Fork::new(Repeat)
+                        .arm(Branch::new("def"))
+                        .then(&token_b)
+                ))
+                .then(&token_b)
+        );
 
-        parent.insert(child);
-
-        assert!(parent == expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", parent, expected);
+        assert_eq!(parent, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", parent, expected);
     }
 
     #[test]
@@ -1042,32 +237,255 @@ mod tests {
         let token_a = token("ABC");
         let token_b = token("DEF");
 
-        let mut parent = Node::Fork(Fork {
-            kind: ForkKind::Repeat,
-            arms: vec![Branch::new(Regex::sequence("def"))],
-            then: Some(Node::Leaf(Leaf::from(&token_b)).boxed()),
-        });
+        let mut parent = Node::Fork(
+            Fork::new(Repeat)
+                .arm(Branch::new("def"))
+                .then(&token_b)
+        );
 
-        let child = Node::Fork(Fork {
-            kind: ForkKind::Plain,
-            arms: vec![branch("abc", Leaf::from(&token_a))],
-            then: None,
-        });
+        parent.insert(
+            Fork::new(Plain)
+                .arm(Branch::new("abc").then(&token_a))
+        );
 
-        let expected = Node::Fork(Fork {
-            kind: ForkKind::Maybe,
-            arms: vec![
-                branch("abc", Leaf::from(&token_a)),
-                Branch {
-                    regex: Regex::sequence("def"),
-                    then: Some(parent.clone().boxed()),
-                }
-            ],
-            then: Some(Node::Leaf(Leaf::from(&token_b)).boxed()),
-        });
+        let expected = Node::Fork(
+            Fork::new(Maybe)
+                .arm(Branch::new("abc").then(&token_a))
+                .arm(Branch::new("def").then(
+                    Fork::new(Repeat)
+                        .arm(Branch::new("def"))
+                        .then(&token_b)
+                ))
+                .then(&token_b)
+        );
 
-        parent.insert(child);
+        assert_eq!(parent, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", parent, expected);
+    }
 
-        assert!(parent == expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", parent, expected);
+    #[test]
+    fn pack_analog_branches() {
+        let mut node = Node::Fork(
+            Fork::new(Plain)
+                .arm(Branch::new("a"))
+                .arm(Branch::new("b"))
+                .arm(Branch::new("c"))
+        );
+
+        node.pack();
+
+        let expected = Node::Branch(
+            Branch::new(Pattern::Range(b'a', b'c'))
+        );
+
+        assert_eq!(node, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", node, expected);
+    }
+
+    #[test]
+    fn pack_analog_branches_with_leaves() {
+        let token = token("ABC");
+
+        let mut node = Node::Fork(
+            Fork::new(Plain)
+                .arm(Branch::new("a").then(&token))
+                .arm(Branch::new("b").then(&token))
+                .arm(Branch::new("c").then(&token))
+        );
+
+        node.pack();
+
+        let expected = Node::Branch(
+            Branch::new(Pattern::Range(b'a', b'c')).then(&token)
+        );
+
+        assert_eq!(node, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", node, expected);
+    }
+
+    #[test]
+    fn pack_analog_branches_with_some_leaves() {
+        let token = token("ABC");
+
+        let mut node = Node::Fork(
+            Fork::new(Plain)
+                .arm(Branch::new("a").then(&token))
+                .arm(Branch::new("b"))
+                .arm(Branch::new("c").then(&token))
+                .arm(Branch::new("d"))
+                .arm(Branch::new("e").then(&token))
+                .arm(Branch::new("f"))
+        );
+
+        node.pack();
+
+        let expected = Node::Fork(
+            Fork::new(Plain)
+                .arm(Branch::new(Pattern::from(&b"ace"[..])).then(&token))
+                .arm(Branch::new(Pattern::from(&b"bdf"[..])))
+        );
+
+        assert_eq!(node, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", node, expected);
+    }
+
+    #[test]
+    fn pack_analog_branches_with_different_leaves() {
+        let abc = token("ABC");
+        let def = token("DEF");
+
+        let mut node = Node::Fork(
+            Fork::new(Plain)
+                .arm(Branch::new("a").then(&abc))
+                .arm(Branch::new("b").then(&abc))
+                .arm(Branch::new("c").then(&abc))
+                .arm(Branch::new("d").then(&def))
+                .arm(Branch::new("e").then(&def))
+                .arm(Branch::new("f").then(&def))
+        );
+
+        node.pack();
+
+        let expected = Node::Fork(
+            Fork::new(Plain)
+                .arm(Branch::new(Pattern::Range(b'a', b'c')).then(&abc))
+                .arm(Branch::new(Pattern::Range(b'd', b'f')).then(&def))
+        );
+
+        assert_eq!(node, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", node, expected);
+    }
+
+    #[test]
+    fn pack_branches() {
+        let mut node = Node::Branch(
+            Branch::new("abc").then(
+                Branch::new("def").then(
+                    Branch::new("xyz")
+                )
+            )
+        );
+
+        node.pack();
+
+        let expected = Node::Branch(
+            Branch::new("abcdefxyz")
+        );
+
+        assert_eq!(node, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", node, expected);
+    }
+
+    #[test]
+    fn pack_branches_with_a_fork() {
+        let mut node = Node::from_regex("abc(1|2|3|4|5)xyz", None);
+
+        assert_eq!(node, Node::Branch(
+            Branch::new("abc").then(
+                Fork::new(Plain)
+                    .arm(Branch::new("1").then(Branch::new("xyz")))
+                    .arm(Branch::new("2").then(Branch::new("xyz")))
+                    .arm(Branch::new("3").then(Branch::new("xyz")))
+                    .arm(Branch::new("4").then(Branch::new("xyz")))
+                    .arm(Branch::new("5").then(Branch::new("xyz")))
+            )
+        ));
+
+        node.pack();
+
+        let expected = Node::Branch(Branch::new(&[
+            Pattern::Byte(b'a'),
+            Pattern::Byte(b'b'),
+            Pattern::Byte(b'c'),
+            Pattern::Range(b'1', b'5'),
+            Pattern::Byte(b'x'),
+            Pattern::Byte(b'y'),
+            Pattern::Byte(b'z'),
+        ][..]));
+
+        assert_eq!(node, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", node, expected);
+    }
+
+    #[test]
+    fn fork_insert() {
+        let int = token("INTEGER");
+        let hex = token("HEX");
+
+        let int_node = Node::from_regex("[0-9]+", Some(Leaf::from(&int)));
+        let hex_node = Node::from_regex("0x[0-9a-f]+", Some(Leaf::from(&hex)));
+
+        let mut fork = Fork::new(Plain);
+
+        fork.insert(int_node);
+        fork.insert(hex_node);
+        fork.pack();
+
+        let expected =
+            Fork::new(Plain)
+                .arm(
+                    Branch::new("0").then(
+                        Fork::new(Maybe)
+                            .arm(
+                                Branch::new(&[
+                                    Pattern::Byte(b'x'),
+                                    Pattern::from(&b"0123456789abcdef"[..]),
+                                ][..]).then(
+                                    Fork::new(Repeat)
+                                        .arm(Branch::new(Pattern::from(&b"0123456789abcdef"[..])))
+                                        .then(&int)
+                                )
+                            )
+                            .arm(
+                                Branch::new(Pattern::Range(b'0', b'9'))
+                                    .then(
+                                        Fork::new(Repeat)
+                                            .arm(Branch::new(Pattern::Range(b'0', b'9')))
+                                            .then(&int)
+                                    )
+                            )
+                            .then(&int)
+                    )
+                )
+                .arm(
+                    Branch::new(Pattern::Range(b'0', b'9')).then(
+                        Fork::new(Repeat)
+                            .arm(Branch::new(Pattern::Range(b'0', b'9')))
+                            .then(&int)
+                    )
+                );
+
+        let mut packed = expected.clone();
+
+        packed.pack();
+
+        assert_eq!(packed, expected, "Not equal:\n\nPACKED {:#?}\n\nEXPECTED {:#?}", packed, expected);
+        assert_eq!(fork, expected, "Not equal:\n\nGOT {:#?}\n\nEXPECTED {:#?}", fork, expected);
+    }
+
+    #[test]
+    fn fork_insert_ordering() {
+        let int   = token("INTEGER");
+        let hex   = token("HEX");
+        let float = token("FLOAT");
+
+        let int_node = Node::from_regex("[0-9]+", Some(Leaf::from(&int)));
+        let hex_node = Node::from_regex("0x[0-9a-f]+", Some(Leaf::from(&hex)));
+        let float_node = Node::from_regex("[0-9]+\\.[0-9]+", Some(Leaf::from(&float)));
+
+        let mut fork_a = Fork::new(Plain);
+        let mut fork_b = Fork::new(Plain);
+        let mut fork_c = Fork::new(Plain);
+
+        fork_a.insert(int_node.clone());
+        fork_a.insert(hex_node.clone());
+        fork_a.insert(float_node.clone());
+        fork_a.pack();
+
+        fork_b.insert(float_node.clone());
+        fork_b.insert(hex_node.clone());
+        fork_b.insert(int_node.clone());
+        fork_b.pack();
+
+        fork_c.insert(hex_node.clone());
+        fork_c.insert(int_node.clone());
+        fork_c.insert(float_node.clone());
+        fork_c.pack();
+
+        assert_eq!(fork_a, fork_b, "Not equal:\n\nA {:#?}\n\nB {:#?}", fork_a, fork_b);
+        assert_eq!(fork_a, fork_c, "Not equal:\n\nA {:#?}\n\nC {:#?}", fork_a, fork_c);
     }
 }

--- a/logos-derive/src/tree.rs
+++ b/logos-derive/src/tree.rs
@@ -1,6 +1,6 @@
 use std::{mem, fmt};
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::regex::{Regex, RepetitionFlag};
 
@@ -475,7 +475,7 @@ impl<'a> Fork<'a> {
         self.arms.iter_mut().for_each(Branch::pack);
 
         if self.arms.len() > 1 {
-            let mut scan: HashMap<&Option<Box<Node>>, usize> = HashMap::new();
+            let mut scan: HashMap<&Option<Box<Node>>, usize> = HashMap::default();
             let mut remove = Vec::new();
 
             for (index, arm) in self.arms.iter_mut().enumerate() {

--- a/logos-derive/src/tree.rs
+++ b/logos-derive/src/tree.rs
@@ -372,7 +372,7 @@ mod tests {
 
     #[test]
     fn pack_branches_with_a_fork() {
-        let mut node = Node::from_regex("abc(1|2|3|4|5)xyz", None);
+        let mut node = Node::from_regex("abc(1|2|3|4|5)xyz", true, None);
 
         assert_eq!(node, Node::Branch(
             Branch::new("abc").then(
@@ -405,8 +405,8 @@ mod tests {
         let int = token("INTEGER");
         let hex = token("HEX");
 
-        let int_node = Node::from_regex("[0-9]+", Some(Leaf::from(&int)));
-        let hex_node = Node::from_regex("0x[0-9a-f]+", Some(Leaf::from(&hex)));
+        let int_node = Node::from_regex("[0-9]+", true, Some(Leaf::from(&int)));
+        let hex_node = Node::from_regex("0x[0-9a-f]+", true, Some(Leaf::from(&hex)));
 
         let mut fork = Fork::new(Plain);
 
@@ -461,8 +461,8 @@ mod tests {
         let ab = token("AB");
         let a  = token("A");
 
-        let ab_node = Node::from_regex("[ab]+", Some(Leaf::from(&ab)));
-        let ac_node = Node::from_regex("a+", Some(Leaf::from(&a)));
+        let ab_node = Node::from_regex("[ab]+", true, Some(Leaf::from(&ab)));
+        let ac_node = Node::from_regex("a+", true, Some(Leaf::from(&a)));
 
         let mut fork = Fork::new(Plain);
 
@@ -491,9 +491,9 @@ mod tests {
         let hex   = token("HEX");
         let float = token("FLOAT");
 
-        let int_node = Node::from_regex("[0-9]+", Some(Leaf::from(&int)));
-        let hex_node = Node::from_regex("0x[0-9a-f]+", Some(Leaf::from(&hex)));
-        let float_node = Node::from_regex("[0-9]+\\.[0-9]+", Some(Leaf::from(&float)));
+        let int_node = Node::from_regex("[0-9]+", true, Some(Leaf::from(&int)));
+        let hex_node = Node::from_regex("0x[0-9a-f]+", true, Some(Leaf::from(&hex)));
+        let float_node = Node::from_regex("[0-9]+\\.[0-9]+", true, Some(Leaf::from(&float)));
 
         let mut fork_a = Fork::new(Plain);
         let mut fork_b = Fork::new(Plain);

--- a/logos-derive/src/tree.rs
+++ b/logos-derive/src/tree.rs
@@ -372,7 +372,7 @@ mod tests {
 
     #[test]
     fn pack_branches_with_a_fork() {
-        let mut node = Node::from_regex("abc(1|2|3|4|5)xyz", true, None);
+        let mut node = Node::from_regex("abc(1|2|3|4|5)xyz", true);
 
         assert_eq!(node, Node::Branch(
             Branch::new("abc").then(
@@ -405,8 +405,8 @@ mod tests {
         let int = token("INTEGER");
         let hex = token("HEX");
 
-        let int_node = Node::from_regex("[0-9]+", true, Some(Leaf::from(&int)));
-        let hex_node = Node::from_regex("0x[0-9a-f]+", true, Some(Leaf::from(&hex)));
+        let int_node = Node::from_regex("[0-9]+", true).leaf(Leaf::from(&int));
+        let hex_node = Node::from_regex("0x[0-9a-f]+", true).leaf(Leaf::from(&hex));
 
         let mut fork = Fork::new(Plain);
 
@@ -461,8 +461,8 @@ mod tests {
         let ab = token("AB");
         let a  = token("A");
 
-        let ab_node = Node::from_regex("[ab]+", true, Some(Leaf::from(&ab)));
-        let ac_node = Node::from_regex("a+", true, Some(Leaf::from(&a)));
+        let ab_node = Node::from_regex("[ab]+", true).leaf(Leaf::from(&ab));
+        let ac_node = Node::from_regex("a+", true).leaf(Leaf::from(&a));
 
         let mut fork = Fork::new(Plain);
 
@@ -491,9 +491,9 @@ mod tests {
         let hex   = token("HEX");
         let float = token("FLOAT");
 
-        let int_node = Node::from_regex("[0-9]+", true, Some(Leaf::from(&int)));
-        let hex_node = Node::from_regex("0x[0-9a-f]+", true, Some(Leaf::from(&hex)));
-        let float_node = Node::from_regex("[0-9]+\\.[0-9]+", true, Some(Leaf::from(&float)));
+        let int_node = Node::from_regex("[0-9]+", true).leaf(Leaf::from(&int));
+        let hex_node = Node::from_regex("0x[0-9a-f]+", true).leaf(Leaf::from(&hex));
+        let float_node = Node::from_regex("[0-9]+\\.[0-9]+", true).leaf(Leaf::from(&float));
 
         let mut fork_a = Fork::new(Plain);
         let mut fork_b = Fork::new(Plain);

--- a/logos-derive/src/tree.rs
+++ b/logos-derive/src/tree.rs
@@ -473,16 +473,11 @@ impl<'a> Fork<'a> {
 
     /// Minimum amount of bytes that will satisfy this Fork
     pub fn min_bytes(&self) -> usize {
-        match self.kind {
-            ForkKind::Repeat | ForkKind::Maybe => 0,
-            ForkKind::Plain => {
-                self.arms
-                    .iter()
-                    .map(|arm| arm.min_bytes())
-                    .min()
-                    .unwrap_or(0)
-            }
-        }
+        self.arms
+            .iter()
+            .map(|arm| arm.min_bytes())
+            .min()
+            .unwrap_or(0)
     }
 
     pub fn pack(&mut self) {
@@ -750,7 +745,8 @@ impl<'a> Node<'a> {
 
     pub fn min_bytes(&self) -> usize {
         match self {
-            Node::Fork(fork) => fork.min_bytes(),
+            Node::Fork(fork) if fork.kind == ForkKind::Plain => fork.min_bytes(),
+            Node::Fork(_) => 0,
             Node::Branch(branch) => branch.min_bytes(),
             Node::Leaf(_) => 0,
         }

--- a/logos-derive/src/tree.rs
+++ b/logos-derive/src/tree.rs
@@ -641,15 +641,6 @@ impl<'a> Node<'a> {
         }
     }
 
-    /// Tests whether all branches have a `then` node set to `Some`.
-    pub fn is_bounded(&self) -> bool {
-        match self {
-            Node::Leaf(_) => true,
-            Node::Branch(branch) => branch.then.is_some(),
-            Node::Fork(fork) => fork.arms.iter().all(|branch| branch.then.is_some()),
-        }
-    }
-
     /// Checks if the fork contains one branch that is a generalization of all other branches,
     /// and if so removes and returns that branch.
     pub fn fallback(&mut self) -> Option<Branch<'a>> {

--- a/logos-derive/src/tree/branch.rs
+++ b/logos-derive/src/tree/branch.rs
@@ -1,0 +1,141 @@
+use std::fmt;
+use std::cmp::Ordering;
+
+use super::Node;
+use super::ForkKind::*;
+use crate::regex::{Regex, Pattern};
+
+#[derive(Clone, Default, PartialEq, Eq, Hash)]
+pub struct Branch<'a> {
+    pub regex: Regex,
+    pub then: Option<Box<Node<'a>>>,
+}
+
+impl<'a> Branch<'a> {
+    pub fn new<R>(regex: R) -> Self
+    where
+        R: Into<Regex>,
+    {
+        Branch {
+            regex: regex.into(),
+            then: None,
+        }
+    }
+
+    pub fn then<Then>(self, then: Then) -> Self
+    where
+        Then: Into<Node<'a>>
+    {
+        Branch {
+            regex: self.regex,
+            then: Some(then.into().boxed())
+        }
+    }
+
+    pub fn compare(&self, other: &Branch<'a>) -> Ordering {
+        other.regex.first().partial_cmp(self.regex.first()).unwrap_or_else(|| Ordering::Greater)
+    }
+
+    pub fn chain(&mut self, then: &Node<'a>) {
+        match self.then {
+            Some(ref mut node) => node.chain(then),
+            None => {
+                self.then = Some(then.clone().boxed());
+            },
+        }
+    }
+
+    pub fn insert_then<Other>(&mut self, other: Other)
+    where
+        Other: Into<Option<Box<Node<'a>>>>,
+    {
+        let other = other.into();
+
+        match self.then {
+            Some(ref mut node) => {
+                match other {
+                    Some(other) => node.insert(*other),
+                    None => node.make_maybe_fork(),
+                }
+            }
+            ref mut then => *then = other,
+        }
+    }
+
+    pub fn to_node(self) -> Option<Node<'a>> {
+        if self.regex.len() == 0 {
+            self.then.map(|node| *node)
+        } else {
+            Some(Node::Branch(self))
+        }
+    }
+
+    pub fn is_finite(&self) -> bool {
+        match self.then {
+            Some(ref node) => match **node {
+                Node::Fork(ref fork) => fork.kind == Plain,
+                _ => true,
+            },
+            None => false,
+        }
+    }
+
+    pub fn matches(&self, pattern: &Pattern) -> bool {
+        self.regex
+            .patterns()
+            .iter()
+            .all(|pat| pattern.contains(pat))
+    }
+
+    pub fn min_bytes(&self) -> usize {
+        self.regex.len() + self.then.as_ref().map(|node| node.min_bytes()).unwrap_or(0)
+    }
+
+    pub fn pack(&mut self) {
+        if let Some(ref mut then) = self.then {
+            then.pack();
+
+            match &mut **then {
+                Node::Branch(branch) => {
+                    if let Some(next) = &mut branch.then {
+                        next.pack();
+                    }
+
+                    self.regex.extend(branch.regex.patterns());
+                    self.then = branch.then.take();
+                },
+                Node::Fork(fork) => fork.pack(),
+                Node::Leaf(_) => {},
+            }
+        }
+    }
+}
+
+impl<'a> fmt::Debug for Branch<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.regex.fmt(f)?;
+
+        if let Some(ref then) = self.then {
+            f.write_str(" -> ")?;
+            then.fmt(f)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> From<Branch<'a>> for Node<'a> {
+    fn from(branch: Branch<'a>) -> Self {
+        if branch.regex.len() == 0 {
+            *branch.then.expect("Cannot convert an empty branch to a Node!")
+        } else {
+            Node::Branch(branch)
+        }
+    }
+}
+
+impl<'a> From<Branch<'a>> for Option<Box<Node<'a>>> {
+    fn from(branch: Branch<'a>) -> Self {
+        branch.to_node().map(Box::new)
+    }
+}

--- a/logos-derive/src/tree/fork.rs
+++ b/logos-derive/src/tree/fork.rs
@@ -1,0 +1,380 @@
+use std::{mem, fmt};
+use rustc_hash::FxHashMap as HashMap;
+
+use super::{Node, Branch};
+use crate::regex::Pattern;
+
+#[derive(Clone, Default, PartialEq, Eq, Hash)]
+pub struct Fork<'a> {
+    pub kind: ForkKind,
+    pub arms: Vec<Branch<'a>>,
+    pub then: Option<Box<Node<'a>>>,
+}
+
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ForkKind {
+    Plain  = 0,
+    Maybe  = 1,
+    Repeat = 2,
+}
+
+pub use self::ForkKind::*;
+
+impl Default for ForkKind {
+    fn default() -> Self {
+        ForkKind::Plain
+    }
+}
+
+impl<'a> Fork<'a> {
+    pub fn new(kind: ForkKind) -> Self {
+        Fork {
+            kind,
+            arms: Vec::new(),
+            then: None,
+        }
+    }
+
+    pub fn arm(mut self, arm: Branch<'a>) -> Self {
+        self.arms.push(arm);
+        self
+    }
+
+    pub fn then<Then>(mut self, then: Then) -> Self
+    where
+        Then: Into<Node<'a>>
+    {
+        self.then = Some(then.into().boxed());
+        self
+    }
+
+    pub fn insert<Then>(&mut self, then: Then)
+    where
+        Then: Into<Node<'a>>,
+    {
+        let then = then.into();
+
+        match then {
+            Node::Branch(branch) => {
+                // If possible, we unwind repeat forks and collapse maybe forks.
+                self.unwind();
+                self.collapse();
+
+                self.insert_branch(branch);
+            },
+            Node::Leaf(leaf) => {
+                if self.then.is_none() {
+                    assert!(
+                        self.kind == Plain,
+                        "Internal Error: Invalid fork construction: {:#?}", self
+                    );
+
+                    self.kind = Maybe;
+                    self.then = Some(Node::Leaf(leaf).boxed());
+                } else {
+                    self.unwind();
+                    self.collapse();
+
+                    assert!(
+                        self.kind != Plain,
+                        "Internal Error: Invalid fork construction: {:#?}", self
+                    );
+
+                    self.kind = Maybe;
+                    self.then = Some(Node::Leaf(leaf).boxed());
+                }
+
+                // FIXME: look up through all tokens produced by `self.then`,
+                //        if they point at a token different from `token`,
+                //        panic with an error about conflicting definitions!
+            },
+            Node::Fork(mut other) => {
+                if self.kind == other.kind && self.arms == other.arms {
+                    self.insert_then(other.then.take());
+
+                    return;
+                }
+
+                // If possible, we unwind repeat forks and collapse maybe forks.
+                self.unwind();
+                self.collapse();
+                other.unwind();
+                other.collapse();
+
+                if other.kind > self.kind {
+                    self.kind = other.kind;
+                }
+
+                self.insert_then(other.then.take());
+
+                for branch in other.arms.into_iter() {
+                    self.insert_branch(branch);
+                }
+            }
+        }
+    }
+
+    pub fn insert_branch(&mut self, mut branch: Branch<'a>) {
+        if branch.regex.len() == 0 {
+            return self.insert_then(branch.then);
+        }
+
+        // Looking for intersection prefixes, that is: A ≠ B & (A ⊂ B | B ⊂ A)
+        for other in self.arms.iter_mut().filter(|arm| arm.is_finite()) {
+            if let Some(prefix) = branch.regex.common_prefix(&other.regex) {
+                let mut intersection = Branch::new(prefix);
+
+                let mut a = branch.clone();
+                let mut b = other.clone();
+
+                a.regex.unshift();
+                b.regex.unshift();
+
+                intersection.insert_then(a);
+                intersection.insert_then(b);
+
+                if intersection.regex.first() == branch.regex.first() {
+                    branch = intersection;
+                } else {
+                    mem::swap(other, &mut intersection);
+                }
+            }
+        }
+
+        // Look for a branch that matches the same prefix
+        for other in self.arms.iter_mut() {
+            // We got a match!
+            if let Some(regex) = branch.regex.match_split(&mut other.regex) {
+                let old = mem::replace(other, Branch::new(regex));
+
+                let a = branch.to_node().map(Box::new);
+                let b = old.to_node().map(Box::new);
+
+                let maybe_fork = a.is_none() || b.is_none();
+
+                other.insert_then(a);
+                other.insert_then(b);
+
+                if maybe_fork {
+                    if let Some(ref mut then) = other.then {
+                        then.make_maybe_fork();
+                    }
+                }
+
+                return;
+            }
+        }
+
+        self.sorted_insert_arm(branch);
+    }
+
+    fn sorted_insert_arm(&mut self, branch: Branch<'a>) {
+        // Sort arms of the fork, simple bytes in alphabetical order first, patterns last
+        match self.arms.binary_search_by(|other| branch.compare(other)) {
+            Ok(index) => {
+                self.arms[index].insert_then(branch);
+            },
+            Err(index) => {
+                self.arms.insert(index, branch.into());
+            },
+        }
+    }
+
+    pub fn insert_then<Other>(&mut self, other: Other)
+    where
+        Other: Into<Option<Box<Node<'a>>>>,
+    {
+        let other = other.into();
+
+        match self.then {
+            Some(ref mut node) => {
+                match other {
+                    Some(other) => node.insert(*other),
+                    None => node.make_maybe_fork(),
+                }
+            }
+            None => {
+                if other.is_some() {
+                    assert!(
+                        self.kind != Repeat,
+                        "Internal Error: Invalid fork construction"
+                    );
+
+                    self.kind = Maybe;
+                    self.then = other;
+                }
+            },
+        }
+    }
+
+    /// Unwinds a Repeat fork into a Maybe fork
+    pub fn unwind(&mut self) {
+        if self.kind != Repeat {
+            return;
+        }
+
+        let repeat = Node::from(self.clone());
+
+        for branch in self.arms.iter_mut() {
+            branch.chain(&repeat);
+        }
+
+        if let Some(mut then) = self.then.take() {
+            match *then {
+                Node::Fork(ref mut fork) if fork.kind == Plain => {
+                    for branch in fork.arms.drain(..) {
+                        self.insert_branch(branch);
+                    }
+
+                    return self.kind = Plain;
+                },
+                Node::Branch(ref mut branch) => {
+                    self.insert_branch(branch.clone());
+
+                    return self.kind = Plain;
+                },
+                _ => self.then = Some(then),
+            }
+        }
+
+        self.kind = Maybe;
+    }
+
+    // Attempts to collapse a Maybe fork into a Plain fork.
+    // If `then` on this fork is a `Token`, or if it isn't
+    // set, then it will remain a Maybe fork.
+    pub fn collapse(&mut self) {
+        if self.kind != Maybe {
+            return;
+        }
+
+        let then = match self.then.take() {
+            None => return,
+            Some(node) => node,
+        };
+
+        for branch in self.arms.iter_mut() {
+            branch.chain(&*then);
+        }
+
+        if then.is_token() {
+            self.then = Some(then);
+        } else {
+            self.kind = Plain;
+            self.insert(*then);
+        }
+    }
+
+    pub fn chain(&mut self, then: &Node<'a>) {
+        if self.kind == Plain {
+            for branch in self.arms.iter_mut() {
+                branch.chain(then)
+            }
+        } else {
+            match self.then {
+                Some(ref mut node) => node.chain(then),
+                None => {
+                    self.then = Some(then.clone().boxed());
+                },
+            }
+        }
+    }
+
+    /// Minimum amount of bytes that will satisfy this Fork
+    pub fn min_bytes(&self) -> usize {
+        self.arms
+            .iter()
+            .map(|arm| arm.min_bytes())
+            .min()
+            .unwrap_or(0)
+    }
+
+    pub fn pack(&mut self) {
+        self.collapse();
+
+        if let Some(then) = &mut self.then {
+            then.pack();
+        }
+
+        self.arms.iter_mut().for_each(Branch::pack);
+
+        if self.arms.len() > 1 {
+            let mut scan: HashMap<(&Option<Box<Node>>, &[Pattern]), usize> = HashMap::default();
+            let mut remove = Vec::new();
+
+            for (index, arm) in self.arms.iter_mut().enumerate() {
+                let first = &arm.regex.patterns()[0];
+                let tail = &arm.regex.patterns()[1..];
+
+                let retain = *scan.entry((&arm.then, tail)).or_insert(index);
+
+                if retain != index {
+                    remove.push((retain, index, first.clone()));
+                }
+            }
+
+            for (retain, index, pattern) in remove.into_iter().rev() {
+                self.arms[retain].regex.first_mut().combine(pattern);
+                self.arms.remove(index);
+            }
+
+            for arm in self.arms.iter_mut() {
+                arm.regex.first_mut().pack();
+            }
+        }
+
+        if self.kind == Maybe && self.arms.len() == 1 && self.arms[0].then == self.then {
+            self.arms[0].then = None;
+        }
+    }
+}
+
+impl fmt::Debug for ForkKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ForkKind::Plain => Ok(()),
+            ForkKind::Maybe => f.write_str("MAYBE "),
+            ForkKind::Repeat => f.write_str("REPEAT "),
+        }
+    }
+}
+
+impl<'a> fmt::Debug for Fork<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.kind.fmt(f)?;
+
+        if self.arms.len() == 1 && self.arms[0].then.is_none() {
+            f.write_str("[")?;
+            self.arms[0].fmt(f)?;
+            f.write_str("]")?;
+        } else {
+            f.debug_list().entries(self.arms.iter()).finish()?;
+        }
+
+        if let Some(ref then) = self.then {
+            f.write_str(" -> ")?;
+            then.fmt(f)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> From<Fork<'a>> for Node<'a> {
+    fn from(fork: Fork<'a>) -> Self {
+        if fork.arms.len() == 0 {
+            if let Some(then) = fork.then {
+                return *then;
+            }
+        }
+
+        Node::Fork(fork)
+    }
+}
+
+impl<'a> From<Fork<'a>> for Box<Node<'a>> {
+    fn from(fork: Fork<'a>) -> Self {
+        Node::from(fork).boxed()
+    }
+}

--- a/logos-derive/src/tree/fork.rs
+++ b/logos-derive/src/tree/fork.rs
@@ -84,10 +84,6 @@ impl<'a> Fork<'a> {
                     self.kind = Maybe;
                     self.then = Some(Node::Leaf(leaf).boxed());
                 }
-
-                // FIXME: look up through all tokens produced by `self.then`,
-                //        if they point at a token different from `token`,
-                //        panic with an error about conflicting definitions!
             },
             Node::Fork(mut other) => {
                 if self.kind == other.kind && self.arms == other.arms {
@@ -198,7 +194,7 @@ impl<'a> Fork<'a> {
                     Some(other) => node.insert(*other),
                     None => node.make_maybe_fork(),
                 }
-            }
+            },
             None => {
                 if other.is_some() {
                     assert!(

--- a/logos-derive/src/tree/leaf.rs
+++ b/logos-derive/src/tree/leaf.rs
@@ -1,0 +1,54 @@
+use std::fmt;
+
+use super::Node;
+
+pub type Token<'a> = &'a ::syn::Ident;
+pub type Callback = ::syn::Ident;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Leaf<'a> {
+    pub token: Token<'a>,
+    pub callback: Option<Callback>,
+}
+
+impl<'a> Leaf<'a> {
+    pub fn take(&mut self) -> Leaf<'a> {
+        Leaf {
+            token: self.token,
+            callback: self.callback.take(),
+        }
+    }
+}
+
+impl<'a> fmt::Debug for Leaf<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.token)?;
+
+        if let Some(ref callback) = self.callback {
+            write!(f, " ({})", callback)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> From<Token<'a>> for Leaf<'a> {
+    fn from(token: Token<'a>) -> Self {
+        Leaf {
+            token,
+            callback: None,
+        }
+    }
+}
+
+impl<'a> From<Token<'a>> for Node<'a> {
+    fn from(token: Token<'a>) -> Self {
+        Node::Leaf(token.into())
+    }
+}
+
+impl<'a> From<Leaf<'a>> for Node<'a> {
+    fn from(leaf: Leaf<'a>) -> Self {
+        Node::Leaf(leaf)
+    }
+}

--- a/logos-derive/src/tree/node.rs
+++ b/logos-derive/src/tree/node.rs
@@ -1,0 +1,244 @@
+use std::{mem, fmt};
+
+use super::{Branch, Leaf, Fork, Token};
+use super::ForkKind::*;
+
+use crate::handlers::Fallback;
+use crate::regex::{Regex, Pattern, RepetitionFlag};
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum Node<'a> {
+    Branch(Branch<'a>),
+    Fork(Fork<'a>),
+    Leaf(Leaf<'a>),
+}
+
+impl<'a> Node<'a> {
+    pub fn new(regex: Regex, leaf: Leaf<'a>) -> Self {
+        if regex.len() == 0 {
+            Node::Leaf(leaf)
+        } else {
+            Node::Branch(Branch::new(regex).then(leaf))
+        }
+    }
+
+    pub fn is_leaf(&self) -> bool {
+        match self {
+            Node::Leaf(_) => true,
+            _ => false,
+        }
+    }
+
+    fn to_mut_fork(&mut self) -> &mut Fork<'a> {
+        match self {
+            Node::Fork(fork) => return fork,
+            Node::Branch(ref mut branch) => {
+                let branch = mem::replace(branch, Branch::default());
+
+                *self = Node::Fork(Fork::new(Plain).arm(branch))
+            },
+            Node::Leaf(leaf) => {
+                *self = Node::Fork(Fork::new(Maybe).then(leaf.take()))
+            }
+        };
+
+        if let Node::Fork(fork) = self {
+            fork
+        } else {
+            panic!("Internal Error: Failed to convert node to a Fork")
+        }
+    }
+
+    pub fn make_maybe_fork(&mut self) {
+        match self {
+            Node::Fork(fork) => {
+                assert!(fork.kind != Repeat);
+
+                return fork.kind = Maybe;
+            },
+            Node::Branch(ref mut branch) => {
+                let branch = mem::replace(branch, Branch::default());
+
+                *self = Node::Fork(Fork::new(Maybe).arm(branch));
+            },
+            Node::Leaf(_) => {},
+        }
+    }
+
+    pub fn insert<Then>(&mut self, then: Then)
+    where
+        Then: Into<Node<'a>>,
+    {
+        let then = then.into();
+
+        if self.is_leaf() && then.is_leaf() {
+            return;
+        }
+
+        let fork = self.to_mut_fork();
+
+        fork.insert(then);
+
+        if fork.arms.len() == 0 {
+            if let Some(then) = fork.then.take() {
+                *self = *then;
+            }
+        }
+    }
+
+    pub fn make_repeat(&mut self, flag: RepetitionFlag) {
+        use self::RepetitionFlag::*;
+
+        if let Node::Branch(branch) = self {
+            if flag == OneOrMore {
+                let mut next = Node::from(branch.clone());
+
+                next.to_mut_fork().kind = Repeat;
+
+                return branch.then = Some(next.boxed());
+            }
+        }
+
+        let fork = self.to_mut_fork();
+
+        match flag {
+            ZeroOrOne => fork.kind = Maybe,
+            ZeroOrMore => fork.kind = Repeat,
+            OneOrMore => {
+                let mut next: Fork = fork.clone();
+
+                next.kind = Repeat;
+
+                fork.insert_then(Some(next.into()));
+            }
+        }
+    }
+
+    /// Checks if all branches in the node match a specific pattern
+    pub fn matches(&self, pattern: &Pattern) -> bool {
+        match self {
+            Node::Branch(branch) => branch.matches(pattern),
+            Node::Fork(fork) => {
+                fork.arms.iter().all(|arm| arm.matches(pattern))
+                    && fork.then.as_ref().map(|then| then.matches(pattern)).unwrap_or(true)
+            },
+            Node::Leaf(_) => true,
+        }
+    }
+
+    pub fn fallback(&self) -> Option<Fallback<'a>> {
+        match self {
+            Node::Fork(fork) => {
+                let arm = &fork.arms[0];
+                let leaf = match &fork.then {
+                    Some(node) => match **node {
+                        Node::Leaf(ref leaf) => leaf,
+                        _ => return None,
+                    },
+                    _ => return None,
+                };
+
+                if fork.kind == Repeat
+                    && fork.arms.len() == 1
+                    && arm.regex.len() == 1
+                    && arm.then.is_none()
+                {
+                    Some(Fallback {
+                        boundary: arm.regex.first().clone(),
+                        leaf: leaf.clone(),
+                    })
+                } else {
+                    None
+                }
+            },
+            _ => None
+        }
+    }
+
+    /// Get all tokens in this tree
+    pub fn get_tokens(&self, vec: &mut Vec<Token<'a>>) {
+        fn insert<'a>(vec: &mut Vec<Token<'a>>, token: Token<'a>) {
+            if let Err(index) = vec.binary_search(&token) {
+                vec.insert(index, token);
+            }
+        }
+
+        match self {
+            Node::Leaf(leaf) => insert(vec, leaf.token),
+            Node::Branch(branch) => {
+                if let Some(ref then) = branch.then {
+                    then.get_tokens(vec);
+                }
+            },
+            Node::Fork(fork) => {
+                for branch in fork.arms.iter() {
+                    if let Some(ref then) = branch.then {
+                        then.get_tokens(vec);
+                    }
+                }
+                if let Some(ref then) = fork.then {
+                    then.get_tokens(vec);
+                }
+            }
+        }
+    }
+
+    pub fn chain(&mut self, then: &Node<'a>) {
+        match self {
+            Node::Branch(branch) => branch.chain(then),
+            Node::Fork(fork) => fork.chain(then),
+            Node::Leaf(_) => {},
+        }
+    }
+
+    pub fn is_token(&self) -> bool {
+        match self {
+            Node::Leaf(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn boxed(self) -> Box<Self> {
+        Box::new(self)
+    }
+
+    pub fn min_bytes(&self) -> usize {
+        match self {
+            Node::Fork(fork) if fork.kind == Plain => fork.min_bytes(),
+            Node::Fork(_) => 0,
+            Node::Branch(branch) => branch.min_bytes(),
+            Node::Leaf(_) => 0,
+        }
+    }
+
+    pub fn pack(&mut self) {
+        match self {
+            Node::Fork(fork) => {
+                fork.pack();
+
+                if fork.kind == Plain
+                    && fork.arms.len() == 1
+                    && (fork.then.is_none() || fork.arms[0].then.is_none())
+                {
+                    let mut branch = fork.arms.remove(0);
+                    branch.then = branch.then.or(fork.then.take());
+                    branch.pack();
+
+                    *self = Node::Branch(branch);
+                }
+            },
+            Node::Branch(branch) => branch.pack(),
+            Node::Leaf(_) => {}
+        }
+    }
+}
+
+impl<'a> fmt::Debug for Node<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Node::Branch(branch) => branch.fmt(f),
+            Node::Fork(fork) => fork.fmt(f),
+            Node::Leaf(leaf) => write!(f, "TOKEN \"{:?}\"", leaf),
+        }
+    }
+}

--- a/logos-derive/src/tree/node.rs
+++ b/logos-derive/src/tree/node.rs
@@ -13,12 +13,18 @@ pub enum Node<'a> {
 }
 
 impl<'a> Node<'a> {
-    pub fn new(regex: Regex, leaf: Leaf<'a>) -> Self {
+    pub fn new(regex: Regex) -> Self {
         if regex.len() == 0 {
-            Node::Leaf(leaf)
-        } else {
-            Node::Branch(Branch::new(regex).then(leaf))
+            panic!("Internal error: Trying to create a Node out of an empty Regex");
         }
+
+        Node::Branch(Branch::new(regex))
+    }
+
+    pub fn leaf(mut self, leaf: Leaf<'a>) -> Self {
+        self.chain(&Node::Leaf(leaf));
+
+        self
     }
 
     pub fn is_leaf(&self) -> bool {
@@ -188,7 +194,8 @@ impl<'a> Node<'a> {
         }
 
         match self {
-            Node::Leaf(leaf) => insert(vec, leaf.token),
+            Node::Leaf(Leaf::Token { token, .. }) => insert(vec, token),
+            Node::Leaf(Leaf::Trivia) => {},
             Node::Branch(branch) => {
                 if let Some(ref then) = branch.then {
                     then.get_tokens(vec);

--- a/logos-derive/src/util.rs
+++ b/logos-derive/src/util.rs
@@ -175,6 +175,20 @@ pub fn ident(ident: &str) -> Ident {
     }
 }
 
+pub fn bytes_to_regex_string(bytes: &[u8]) -> String {
+    let mut string = String::with_capacity(bytes.len());
+
+    for &byte in bytes {
+        if byte < 0x7F {
+            string.push(byte as char);
+        } else {
+            string.push_str(&format!("\\x{:02x}", byte));
+        }
+    }
+
+    string
+}
+
 pub struct MergeAscending<L, R>
 where
     L: Iterator<Item = R::Item>,

--- a/logos/Cargo.toml
+++ b/logos/Cargo.toml
@@ -12,17 +12,13 @@ readme = "../README.md"
 edition = "2018"
 
 [dependencies]
-toolshed = { version = "0.8", optional = true }
-logos-derive = { version = "0.9.7", optional = true }
+logos-derive = { path = "../logos-derive", optional = true }
 
 [features]
 default = ["export_derive", "std"]
 
 # Should the crate use the standard library?
 std = []
-
-# Provides an `impl Source for NulTermStr` from the `toolshed` crate.
-nul_term_source = ["toolshed"]
 
 # Re-exports the `Logos` derive macro, so that end user only needs to
 # import this crate and `use logos::Logos` to get both the trait and

--- a/logos/src/internal.rs
+++ b/logos/src/internal.rs
@@ -1,4 +1,4 @@
-use crate::source::ByteArray;
+use crate::source;
 
 /// Trait used by the functions contained in the `Lexicon`.
 ///
@@ -8,7 +8,7 @@ use crate::source::ByteArray;
 /// code produced by `#[derive(Logos)]` macro.**
 pub trait LexerInternal<'source> {
     /// Read the byte(s) at current position.
-    fn read<Array: ByteArray<'source>>(&self) -> Option<Array>;
+    fn read<Chunk: source::Chunk<'source>>(&self) -> Option<Chunk>;
 
     /// Bump the position by 1 and read the following byte.
     fn next(&mut self) -> Option<u8>;

--- a/logos/src/internal.rs
+++ b/logos/src/internal.rs
@@ -10,8 +10,14 @@ pub trait LexerInternal<'source> {
     /// Read a chunk at current position.
     fn read<Chunk: source::Chunk<'source>>(&self) -> Option<Chunk>;
 
-    /// Read a chunk at current position offset by `size`.
-    fn lookahead<Chunk: source::Chunk<'source>>(&mut self, size: usize) -> Option<Chunk>;
+    /// Read a chunk at current position offset by `n`.
+    fn read_at<Chunk: source::Chunk<'source>>(&self, n: usize) -> Option<Chunk>;
+
+    /// Test a chunk at current position with a closure.
+    fn test<T: source::Chunk<'source>, F: FnOnce(T) -> bool>(&self, test: F) -> bool;
+
+    /// Test a chunk at current position offset by `n` with a closure.
+    fn test_at<T: source::Chunk<'source>, F: FnOnce(T) -> bool>(&self, n: usize, test: F) -> bool;
 
     /// Bump the position by `size`.
     fn bump(&mut self, size: usize);

--- a/logos/src/internal.rs
+++ b/logos/src/internal.rs
@@ -7,16 +7,12 @@ use crate::source::ByteArray;
 /// **This trait, and it's methods, are not meant to be used outside of the
 /// code produced by `#[derive(Logos)]` macro.**
 pub trait LexerInternal<'source> {
-    /// Read the byte at current position.
-    fn read(&self) -> u8;
+    /// Read the byte(s) at current position.
+    fn read<Array: ByteArray<'source>>(&self) -> Option<Array>;
 
     /// Bump the position by 1 and read the following byte.
-    fn next(&mut self) -> u8;
+    fn next(&mut self) -> Option<u8>;
 
-    /// Bump the position by 1.
+    /// Bump the position by `size`.
     fn bump(&mut self, size: usize);
-
-    fn read_bytes<Array>(&self) -> Option<&'source Array>
-    where
-        Array: ByteArray<'source>;
 }

--- a/logos/src/internal.rs
+++ b/logos/src/internal.rs
@@ -7,11 +7,11 @@ use crate::source;
 /// **This trait, and it's methods, are not meant to be used outside of the
 /// code produced by `#[derive(Logos)]` macro.**
 pub trait LexerInternal<'source> {
-    /// Read the byte(s) at current position.
+    /// Read a chunk at current position.
     fn read<Chunk: source::Chunk<'source>>(&self) -> Option<Chunk>;
 
-    /// Bump the position by 1 and read the following byte.
-    fn next(&mut self) -> Option<u8>;
+    /// Read a chunk at current position offset by `size`.
+    fn lookahead<Chunk: source::Chunk<'source>>(&mut self, size: usize) -> Option<Chunk>;
 
     /// Bump the position by `size`.
     fn bump(&mut self, size: usize);

--- a/logos/src/lexer.rs
+++ b/logos/src/lexer.rs
@@ -166,7 +166,7 @@ where
     Token: self::Logos,
     Source: self::Source<'source>,
 {
-    /// Read a byte(s) at current position of the `Lexer`. If end
+    /// Read a `Chunk` at current position of the `Lexer`. If end
     /// of the `Source` has been reached, this will return `0`.
     #[inline]
     fn read<Chunk>(&self) -> Option<Chunk>
@@ -176,12 +176,13 @@ where
         self.source.read_bytes(self.token_end)
     }
 
-    /// Convenience method that bumps the position `Lexer` is
-    /// reading from and then reads the following byte.
+    /// Read a `Chunk` at a position offset by `size`.
     #[inline]
-    fn next(&mut self) -> Option<u8> {
-        self.bump(1);
-        self.read()
+    fn lookahead<Chunk>(&mut self, size: usize) -> Option<Chunk>
+    where
+        Chunk: source::Chunk<'source>
+    {
+        self.source.read_bytes(self.token_end + size)
     }
 
     /// Bump the position `Lexer` is reading from by `size`.

--- a/logos/src/lexer.rs
+++ b/logos/src/lexer.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use crate::source::{self, Source};
+use crate::source::{self, Source, SourceMarker};
 use super::{Logos};
 use super::internal::LexerInternal;
 
@@ -49,6 +49,8 @@ where
     /// Due to type inference, it might be more ergonomic to construct
     /// it by calling `Token::lexer(source)`, where `Token` implements `Logos`.
     pub fn new(source: Source) -> Self {
+        Token::SourceMarker::check_source::<Source>();
+
         let mut lex = Lexer {
             source,
             token: Token::ERROR,
@@ -100,13 +102,7 @@ where
     pub fn slice(&self) -> Source::Slice {
         unsafe { self.source.slice_unchecked(self.range()) }
     }
-}
 
-impl<'source, Token, Source> Lexer<Token, Source>
-where
-    Token: self::Logos,
-    Source: self::Source<'source>,
-{
     /// Turn this lexer into a lexer for a new token type.
     ///
     /// The new lexer continues to point at the same span as the current lexer,
@@ -117,6 +113,8 @@ where
     where
         Token::Extras: Into<Token2::Extras>,
     {
+        Token2::SourceMarker::check_source::<Source>();
+
         Lexer {
             source: self.source,
             token: Token2::ERROR,

--- a/logos/src/lexer.rs
+++ b/logos/src/lexer.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use crate::source::{Source, ByteArray};
+use crate::source::{self, Source};
 use super::{Logos};
 use super::internal::LexerInternal;
 
@@ -169,9 +169,9 @@ where
     /// Read a byte(s) at current position of the `Lexer`. If end
     /// of the `Source` has been reached, this will return `0`.
     #[inline]
-    fn read<Array>(&self) -> Option<Array>
+    fn read<Chunk>(&self) -> Option<Chunk>
     where
-        Array: ByteArray<'source>
+        Chunk: source::Chunk<'source>
     {
         self.source.read_bytes(self.token_end)
     }

--- a/logos/src/lexer.rs
+++ b/logos/src/lexer.rs
@@ -171,18 +171,44 @@ where
     #[inline]
     fn read<Chunk>(&self) -> Option<Chunk>
     where
-        Chunk: source::Chunk<'source>
+        Chunk: source::Chunk<'source>,
     {
-        self.source.read_bytes(self.token_end)
+        self.source.read(self.token_end)
     }
 
-    /// Read a `Chunk` at a position offset by `size`.
+    /// Read a `Chunk` at a position offset by `n`.
     #[inline]
-    fn lookahead<Chunk>(&mut self, size: usize) -> Option<Chunk>
+    fn read_at<Chunk>(&self, n: usize) -> Option<Chunk>
     where
-        Chunk: source::Chunk<'source>
+        Chunk: source::Chunk<'source>,
     {
-        self.source.read_bytes(self.token_end + size)
+        self.source.read(self.token_end + n)
+    }
+
+    /// Test a chunk at current position with a closure.
+    #[inline]
+    fn test<T, F>(&self, test: F) -> bool
+    where
+        T: source::Chunk<'source>,
+        F: FnOnce(T) -> bool,
+    {
+        match self.source.read::<T>(self.token_end) {
+            Some(chunk) => test(chunk),
+            None        => false,
+        }
+    }
+
+    /// Test a chunk at current position offset by `n` with a closure.
+    #[inline]
+    fn test_at<T, F>(&self, n: usize, test: F) -> bool
+    where
+        T: source::Chunk<'source>,
+        F: FnOnce(T) -> bool,
+    {
+        match self.source.read::<T>(self.token_end + n) {
+            Some(chunk) => test(chunk),
+            None        => false,
+        }
     }
 
     /// Bump the position `Lexer` is reading from by `size`.

--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -97,7 +97,7 @@ pub mod source;
 pub mod internal;
 
 pub use self::lexer::{Lexer, Lexicon, Extras};
-pub use self::source::{Source, Slice};
+pub use self::source::{Source, Slice, WithSource};
 
 /// Trait implemented for an enum representing all tokens. You should never have
 /// to implement it manually, use the `#[derive(Logos)]` attribute on your enum.
@@ -106,9 +106,6 @@ pub trait Logos: Sized {
     /// aren't necessarily tokens, such as comments or Automatic Semicolon Insertion
     /// in JavaScript.
     type Extras: self::Extras;
-
-    /// Marker that tells us which `Source`s can be used with this `Logos`.
-    type SourceMarker: crate::source::SourceMarker;
 
     /// `SIZE` is simply a number of possible variants of the `Logos` enum. The
     /// `derive` macro will make sure that all variants don't hold values larger
@@ -126,13 +123,15 @@ pub trait Logos: Sized {
     /// Returns a lookup table for the `Lexer`
     fn lexicon<'lexicon, 'source, Source>() -> &'lexicon Lexicon<Lexer<Self, Source>>
     where
-        Source: self::Source<'source>;
+        Source: self::Source<'source>,
+        Self: WithSource<Source>;
 
     /// Create a new instance of a `Lexer` that will produce tokens implementing
     /// this `Logos`.
     fn lexer<'source, Source>(source: Source) -> Lexer<Self, Source>
     where
         Source: self::Source<'source>,
+        Self: WithSource<Source>,
     {
         Lexer::new(source)
     }

--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -91,7 +91,7 @@ extern crate core as std;
 pub use logos_derive::Logos;
 
 mod lexer;
-mod source;
+pub mod source;
 
 #[doc(hidden)]
 pub mod internal;

--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -107,6 +107,9 @@ pub trait Logos: Sized {
     /// in JavaScript.
     type Extras: self::Extras;
 
+    /// Marker that tells us which `Source`s can be used with this `Logos`.
+    type SourceMarker: crate::source::SourceMarker;
+
     /// `SIZE` is simply a number of possible variants of the `Logos` enum. The
     /// `derive` macro will make sure that all variants don't hold values larger
     /// or equal to `SIZE`.

--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -97,7 +97,7 @@ pub mod source;
 pub mod internal;
 
 pub use self::lexer::{Lexer, Lexicon, Extras};
-pub use self::source::{Source, Slice, WithSource};
+pub use self::source::{Source, Slice};
 
 /// Trait implemented for an enum representing all tokens. You should never have
 /// to implement it manually, use the `#[derive(Logos)]` attribute on your enum.
@@ -124,14 +124,14 @@ pub trait Logos: Sized {
     fn lexicon<'lexicon, 'source, Source>() -> &'lexicon Lexicon<Lexer<Self, Source>>
     where
         Source: self::Source<'source>,
-        Self: WithSource<Source>;
+        Self: source::WithSource<Source>;
 
     /// Create a new instance of a `Lexer` that will produce tokens implementing
     /// this `Logos`.
     fn lexer<'source, Source>(source: Source) -> Lexer<Self, Source>
     where
         Source: self::Source<'source>,
-        Self: WithSource<Source>,
+        Self: source::WithSource<Source>,
     {
         Lexer::new(source)
     }

--- a/logos/src/source.rs
+++ b/logos/src/source.rs
@@ -24,13 +24,13 @@ impl<'source> Slice<'source> for &'source [u8] {
     }
 }
 
-pub trait ByteArray<'source>: Sized + Copy {
+pub trait Chunk<'source>: Sized + Copy {
     const SIZE: usize;
 
     unsafe fn from_ptr(ptr: *const u8) -> Self;
 }
 
-impl<'source> ByteArray<'source> for u8 {
+impl<'source> Chunk<'source> for u8 {
     const SIZE: usize = 1;
 
     #[inline]
@@ -41,7 +41,7 @@ impl<'source> ByteArray<'source> for u8 {
 
 macro_rules! impl_array {
     ($($size:tt),*) => ($(
-        impl<'source> ByteArray<'source> for [u8; $size] {
+        impl<'source> Chunk<'source> for [u8; $size] {
             const SIZE: usize = $size;
 
             #[inline]
@@ -50,7 +50,7 @@ macro_rules! impl_array {
             }
         }
 
-        impl<'source> ByteArray<'source> for &'source [u8; $size] {
+        impl<'source> Chunk<'source> for &'source [u8; $size] {
             const SIZE: usize = $size;
 
             #[inline]
@@ -114,9 +114,9 @@ pub trait Source<'source> {
     /// }
     /// # }
     /// ```
-    fn read_bytes<Array>(&self, offset: usize) -> Option<Array>
+    fn read_bytes<Chunk>(&self, offset: usize) -> Option<Chunk>
     where
-        Array: ByteArray<'source>;
+        Chunk: self::Chunk<'source>;
 
     /// Get a slice of the source at given range. This is analogous to
     /// `slice::get(range)`.
@@ -170,12 +170,12 @@ impl<'source> Source<'source> for &'source str {
     }
 
     #[inline]
-    fn read_bytes<Array>(&self, offset: usize) -> Option<Array>
+    fn read_bytes<Chunk>(&self, offset: usize) -> Option<Chunk>
     where
-        Array: ByteArray<'source>
+        Chunk: self::Chunk<'source>
     {
-        if offset + (Array::SIZE - 1) < (*self).len() {
-            Some(unsafe { Array::from_ptr((*self).as_ptr().add(offset)) })
+        if offset + (Chunk::SIZE - 1) < (*self).len() {
+            Some(unsafe { Chunk::from_ptr((*self).as_ptr().add(offset)) })
         } else {
             None
         }
@@ -216,12 +216,12 @@ impl<'source> Source<'source> for &'source [u8] {
     }
 
     #[inline]
-    fn read_bytes<Array>(&self, offset: usize) -> Option<Array>
+    fn read_bytes<Chunk>(&self, offset: usize) -> Option<Chunk>
     where
-        Array: ByteArray<'source>
+        Chunk: self::Chunk<'source>
     {
-        if offset + (Array::SIZE - 1) < (*self).len() {
-            Some(unsafe { Array::from_ptr((*self).as_ptr().add(offset)) })
+        if offset + (Chunk::SIZE - 1) < (*self).len() {
+            Some(unsafe { Chunk::from_ptr((*self).as_ptr().add(offset)) })
         } else {
             None
         }

--- a/logos/src/source.rs
+++ b/logos/src/source.rs
@@ -56,30 +56,6 @@ macro_rules! impl_array {
             }
         }
 
-        impl<'source> Split<u8> for &'source [u8; $size] {
-            type Remainder = &'source [u8; $size - 1];
-
-            #[inline]
-            fn split(self) -> (u8, &'source [u8; $size - 1]) {
-                unsafe {(
-                    self[0],
-                    Chunk::from_ptr((self as *const u8).add(1)),
-                )}
-            }
-        }
-
-        impl<'source> Split<&'source [u8; $size - 1]> for &'source [u8; $size] {
-            type Remainder = u8;
-
-            #[inline]
-            fn split(self) -> (&'source [u8; $size - 1], u8) {
-                unsafe {(
-                    Chunk::from_ptr(self as *const u8),
-                    self[$size - 1],
-                )}
-            }
-        }
-
         $(
             impl<'source> Split<&'source [u8; $split]> for &'source [u8; $size] {
                 type Remainder = &'source [u8; $size - $split];
@@ -96,39 +72,23 @@ macro_rules! impl_array {
     )*)
 }
 
-impl<'source> Chunk<'source> for &'source [u8; 2] {
-    const SIZE: usize = 2;
-
-    #[inline]
-    unsafe fn from_ptr(ptr: *const u8) -> Self {
-        &*(ptr as *const [u8; 2])
-    }
-}
-
-impl<'source> Split<u8> for &'source [u8; 2] {
-    type Remainder = u8;
-
-    #[inline]
-    fn split(self) -> (u8, u8) {
-        (self[0], self[1])
-    }
-}
-
 impl_array! {
-    3  > ()
-    4  > (2)
-    5  > (2, 3)
-    6  > (2, 3, 4)
-    7  > (2, 3, 4, 5)
-    8  > (2, 3, 4, 5, 6)
-    9  > (2, 3, 4, 5, 6, 7)
-    10 > (2, 3, 4, 5, 6, 7, 8)
-    11 > (2, 3, 4, 5, 6, 7, 8, 9)
-    12 > (2, 3, 4, 5, 6, 7, 8, 9, 10)
-    13 > (2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
-    14 > (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
-    15 > (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
-    16 > (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
+    1  > ()
+    2  > (1)
+    3  > (1, 2)
+    4  > (1, 2, 3)
+    5  > (1, 2, 3, 4)
+    6  > (1, 2, 3, 4, 5)
+    7  > (1, 2, 3, 4, 5, 6)
+    8  > (1, 2, 3, 4, 5, 6, 7)
+    9  > (1, 2, 3, 4, 5, 6, 7, 8)
+    10 > (1, 2, 3, 4, 5, 6, 7, 8, 9)
+    11 > (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    12 > (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+    13 > (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+    14 > (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+    15 > (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
+    16 > (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 }
 
 /// Trait for types the `Lexer` can read from.

--- a/logos/src/source.rs
+++ b/logos/src/source.rs
@@ -98,15 +98,19 @@ pub trait Source<'source> {
     unsafe fn slice_unchecked(&self, range: Range<usize>) -> Self::Slice;
 }
 
-/// Marker trait for any `Source` that can be sliced into arbitrary byte chunks.
+/// Marker trait for any `Source` that can be sliced into arbitrary byte chunks,
+/// with no regard for UTF-8 (or any other) character encoding.
 pub trait BinarySource<'source>: Source<'source> {}
 
-/// Marker trait for any `Logos`, which can constrain it to a specific subset of
-/// `Source`s, should using a particular `Source` produce unsafety.
+/// Marker trait for any `Logos`, which will constrain it to a specific subset of
+/// `Source`s.
 ///
 /// In particular, if your token definitions would allow reading invalid UTF-8,
 /// the `Logos` derive macro will restrict you to lexing on `Source`s that also
 /// implement the `BinarySource` marker (`&[u8]` is provided).
+///
+/// **Note:** You shouldn't implement this trait yourself, `#[derive(Logos)]` will
+/// do it for you.
 pub trait WithSource<Source> {}
 
 impl<'source> Source<'source> for &'source str {

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,8 @@
-cd tests
-cargo test || exit
-
-cd ..
 cd logos-derive
+cargo test || exit
+cd ..
+
+cd tests
 cargo test || exit
 cd ..
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,6 +7,5 @@ repository = "https://github.com/maciejhirsz/logos"
 edition = "2018"
 
 [dependencies]
-logos = { path = "../logos", default-features = false, features = ["nul_term_source"] }
+logos = { path = "../logos", default-features = false, features = ["std"] }
 logos-derive = { path = "../logos-derive" }
-toolshed = "0.8"

--- a/tests/benches/bench.rs
+++ b/tests/benches/bench.rs
@@ -132,55 +132,13 @@ fn identifiers(b: &mut Bencher) {
 }
 
 #[bench]
-fn identifiers_nul_terminated(b: &mut Bencher) {
-    use logos::Logos;
-    use toolshed::Arena;
-
-    let arena = Arena::new();
-    let nts = arena.alloc_nul_term_str(IDENTIFIERS);
-
-    b.bytes = IDENTIFIERS.len() as u64;
-
-    b.iter(|| {
-        let mut lex = Token::lexer(nts);
-
-        while lex.token != Token::EndOfProgram {
-            lex.advance();
-        }
-
-        black_box(lex.token)
-    });
-}
-
-#[bench]
-fn logos(b: &mut Bencher) {
+fn keywords_operators_and_punctators(b: &mut Bencher) {
     use logos::Logos;
 
     b.bytes = SOURCE.len() as u64;
 
     b.iter(|| {
         let mut lex = Token::lexer(SOURCE);
-
-        while lex.token != Token::EndOfProgram {
-            lex.advance();
-        }
-
-        black_box(lex.token)
-    });
-}
-
-#[bench]
-fn logos_nul_terminated(b: &mut Bencher) {
-    use logos::Logos;
-    use toolshed::Arena;
-
-    let arena = Arena::new();
-    let nts = arena.alloc_nul_term_str(SOURCE);
-
-    b.bytes = SOURCE.len() as u64;
-
-    b.iter(|| {
-        let mut lex = Token::lexer(nts);
 
         while lex.token != Token::EndOfProgram {
             lex.advance();

--- a/tests/src/binary.rs
+++ b/tests/src/binary.rs
@@ -73,7 +73,7 @@ enum Token {
 #[test]
 fn handles_non_utf8() {
     assert_lex(
-        &[0, 0, 0xCA, 0xFE, 0xBE, 0xEF, b'f', b'o', b'o', 0x42, 0x42, 0x42, 0xAA, 0xAA, 0xA2, 0xAE][..],
+        &[0, 0, 0xCA, 0xFE, 0xBE, 0xEF, b'f', b'o', b'o', 0x42, 0x42, 0x42, 0xAA, 0xAA, 0xA2, 0xAE, 0x10, 0x20, 0][..],
         &[
             (Token::Zero, &[0], 0..1),
             (Token::Zero, &[0], 1..2),
@@ -81,6 +81,9 @@ fn handles_non_utf8() {
             (Token::Foo, b"foo", 6..9),
             (Token::Life, &[0x42, 0x42, 0x42], 9..12),
             (Token::Aaaaaaa, &[0xAA, 0xAA, 0xA2, 0xAE], 12..16),
+            (Token::Error, &[0x10], 16..17),
+            (Token::Error, &[0x20], 17..18),
+            (Token::Zero, &[0], 18..19),
         ],
     );
 }

--- a/tests/src/binary.rs
+++ b/tests/src/binary.rs
@@ -18,12 +18,35 @@
 //!     Token::lexer("This shouldn't work with a string literal!");
 //! }
 //! ```
+//! Same, but with regex:
+//!
+//! ```compile_fail
+//! use logos::Logos;
+//! use logos_derive::Logos;
+//!
+//! #[derive(Logos)]
+//! enum Token {
+//!     #[end]
+//!     End,
+//!
+//!     #[error]
+//!     Error,
+//!
+//!     #[regex = b"\xFF"]
+//!     NonUtf8,
+//! }
+//!
+//! fn main() {
+//!     Token::lexer("This shouldn't work with a string literal!");
+//! }
+//! ```
 
 pub use super::assert_lex;
 
 use logos_derive::Logos;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
+#[logos(trivia())]
 enum Token {
     #[error]
     Error,
@@ -33,6 +56,12 @@ enum Token {
 
     #[token = "foo"]
     Foo,
+
+    #[regex = b"\x42+"]
+    Life,
+
+    #[regex = b"[\xA0-\xAF]+"]
+    Aaaaaaa,
 
     #[token = b"\xCA\xFE\xBE\xEF"]
     CafeBeef,
@@ -44,13 +73,14 @@ enum Token {
 #[test]
 fn handles_non_utf8() {
     assert_lex(
-        &[0, 0, 0xCA, 0xFE, 0xBE, 0xEF, b'f', b'o', b'o', 0][..],
+        &[0, 0, 0xCA, 0xFE, 0xBE, 0xEF, b'f', b'o', b'o', 0x42, 0x42, 0x42, 0xAA, 0xAA, 0xA2, 0xAE][..],
         &[
             (Token::Zero, &[0], 0..1),
             (Token::Zero, &[0], 1..2),
             (Token::CafeBeef, &[0xCA, 0xFE, 0xBE, 0xEF], 2..6),
             (Token::Foo, b"foo", 6..9),
-            (Token::Zero, &[0], 9..10),
+            (Token::Life, &[0x42, 0x42, 0x42], 9..12),
+            (Token::Aaaaaaa, &[0xAA, 0xAA, 0xA2, 0xAE], 12..16),
         ],
     );
 }

--- a/tests/src/binary.rs
+++ b/tests/src/binary.rs
@@ -1,0 +1,56 @@
+//! ```compile_fail
+//! use logos::Logos;
+//! use logos_derive::Logos;
+//!
+//! #[derive(Logos)]
+//! enum Token {
+//!     #[end]
+//!     End,
+//!
+//!     #[error]
+//!     Error,
+//!
+//!     #[token = b"\xFF"]
+//!     NonUtf8,
+//! }
+//!
+//! fn main() {
+//!     Token::lexer("This shouldn't work with a string literal!");
+//! }
+//! ```
+
+pub use super::assert_lex;
+
+use logos_derive::Logos;
+
+#[derive(Logos, Debug, Clone, Copy, PartialEq)]
+enum Token {
+    #[error]
+    Error,
+
+    #[end]
+    End,
+
+    #[token = "foo"]
+    Foo,
+
+    #[token = b"\xCA\xFE\xBE\xEF"]
+    CafeBeef,
+
+    #[token = b"\x00"]
+    Zero,
+}
+
+#[test]
+fn handles_non_utf8() {
+    assert_lex(
+        &[0, 0, 0xCA, 0xFE, 0xBE, 0xEF, b'f', b'o', b'o', 0][..],
+        &[
+            (Token::Zero, &[0], 0..1),
+            (Token::Zero, &[0], 1..2),
+            (Token::CafeBeef, &[0xCA, 0xFE, 0xBE, 0xEF], 2..6),
+            (Token::Foo, b"foo", 6..9),
+            (Token::Zero, &[0], 9..10),
+        ],
+    );
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,0 +1,20 @@
+use std::fmt;
+use std::ops::Range;
+
+mod binary;
+
+pub fn assert_lex<'a, Source, Token>(source: Source, tokens: &[(Token, Source::Slice, Range<usize>)])
+where
+    Token: logos::Logos + logos::source::WithSource<Source> + fmt::Debug + PartialEq + Clone + Copy,
+    Source: logos::Source<'a>,
+{
+    let mut lex = Token::lexer(source);
+
+    for tuple in tokens {
+        assert_eq!(&(lex.token, lex.slice(), lex.range()), tuple);
+
+        lex.advance();
+    }
+
+    assert_eq!(lex.token, Token::END);
+}

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Run `cargo test` from main project folder");
-}

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -91,7 +91,8 @@ mod advanced {
             (Token::LiteralString, "\"foobar\"", 4..12),
             (Token::LiteralString, "\"escaped\\\"quote\"", 13..29),
             (Token::LiteralString, "\"escaped\\nnew line\"", 30..49),
-            (Token::Error, "\"\\", 50..52),
+            (Token::Error, "\"", 50..51),
+            (Token::Error, "\\", 51..52),
             (Token::Error, "x", 52..53),
             (Token::Error, "\" ", 53..55),
         ]);

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -1,6 +1,5 @@
-use logos::{Logos, lookup};
+use logos::lookup;
 use logos_derive::Logos;
-use std::ops::Range;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
 enum Token {
@@ -66,22 +65,9 @@ enum Token {
     Keyword,
 }
 
-fn assert_lex<'a, Source>(source: Source, tokens: &[(Token, Source::Slice, Range<usize>)])
-where
-    Source: logos::Source<'a>,
-{
-    let mut lex = Token::lexer(source);
-
-    for tuple in tokens {
-        assert_eq!(&(lex.token, lex.slice(), lex.range()), tuple);
-
-        lex.advance();
-    }
-
-    assert_eq!(lex.token, Token::End);
-}
-
 mod advanced {
+    use logos::Logos;
+    use tests::assert_lex;
     use super::*;
 
     #[test]

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -100,8 +100,10 @@ mod advanced {
     #[test]
     fn hex() {
         assert_lex("0x 0X 0x0 0x9 0xa 0xf 0X0 0X9 0XA 0XF 0x123456789abcdefABCDEF 0xdeadBEEF", &[
-            (Token::Error, "0x", 0..2),
-            (Token::Error, "0X", 3..5),
+            (Token::LiteralInteger, "0", 0..1),
+            (Token::Error, "x", 1..2),
+            (Token::LiteralInteger, "0", 3..4),
+            (Token::Error, "X", 4..5),
             (Token::LiteralHex, "0x0", 6..9),
             (Token::LiteralHex, "0x9", 10..13),
             (Token::LiteralHex, "0xa", 14..17),

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -59,6 +59,9 @@ enum Token {
     #[regex = r"[\u0400-\u04FF]+"]
     Cyrillic,
 
+    #[regex = r"([#@!\\?][#@!\\?][#@!\\?][#@!\\?])+"]
+    WhatTheHeck,
+
     #[regex = "try|type|typeof"]
     Keyword,
 }
@@ -188,7 +191,7 @@ mod advanced {
     }
 
     #[test]
-    fn sigs(){
+    fn sigs() {
         assert_lex("~ ~m23 ~s42 ~s42..cafe.babe ~h23 ~sod ~myd ~songname", &[
             (Token::LiteralNull, "~", 0..1),
             (Token::LiteralRelDate, "~m23", 2..6),
@@ -200,13 +203,23 @@ mod advanced {
             (Token::LiteralUrbitAddress, "~songname",43..52),
         ]);
     }
+
     #[test]
-    fn subquotes(){
+    fn subquotes() {
         assert_lex("' ''' ''", &[
             (Token::SingleQuote, "'", 0..1),
             (Token::TripleQuote, "'''", 2..5),
             (Token::SingleQuote, "'", 6..7),
             (Token::SingleQuote, "'", 7..8),
+        ]);
+    }
+
+    #[test]
+    fn what_the_heck() {
+        assert_lex("!#@? #!!!?!@? ????####@@@@!!!!", &[
+            (Token::WhatTheHeck, "!#@?", 0..4),
+            (Token::WhatTheHeck, "#!!!?!@?", 5..13),
+            (Token::WhatTheHeck, "????####@@@@!!!!", 14..30),
         ]);
     }
 }

--- a/tests/tests/css.rs
+++ b/tests/tests/css.rs
@@ -1,6 +1,4 @@
-use logos::Logos;
 use logos_derive::Logos;
-use std::ops::Range;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
 enum Token {
@@ -32,22 +30,8 @@ enum Token {
     Colon,
 }
 
-fn assert_lex<'a, Source>(source: Source, tokens: &[(Token, Source::Slice, Range<usize>)])
-where
-    Source: logos::Source<'a>,
-{
-    let mut lex = Token::lexer(source);
-
-    for tuple in tokens {
-        assert_eq!(&(lex.token, lex.slice(), lex.range()), tuple);
-
-        lex.advance();
-    }
-
-    assert_eq!(lex.token, Token::End);
-}
-
-mod advanced {
+mod css {
+    use tests::assert_lex;
     use super::*;
 
     #[test]

--- a/tests/tests/css.rs
+++ b/tests/tests/css.rs
@@ -85,15 +85,15 @@ mod advanced {
     #[test]
     fn test_letter_spacing() {
         assert_lex(
-            "h3 { letter-spacing: 1Q }",
+            "h3 { letter-spacing: 42em }",
             &[
                 (Token::Ident, "h3", 0..2),
                 (Token::CurlyBracketOpen, "{", 3..4),
                 (Token::Ident, "letter-spacing", 5..19),
                 (Token::Colon, ":", 19..20),
-                (Token::Number, "1", 21..22),
-                (Token::AbsoluteLength, "Q", 22..23),
-                (Token::CurlyBracketClose, "}", 24..25),
+                (Token::Number, "42", 21..23),
+                (Token::RelativeLength, "em", 23..25),
+                (Token::CurlyBracketClose, "}", 26..27),
             ],
         );
     }

--- a/tests/tests/lexer_modes.rs
+++ b/tests/tests/lexer_modes.rs
@@ -6,11 +6,13 @@ use logos_derive::Logos;
 enum Outer {
     #[end]
     End,
+
     #[error]
     Error,
 
     #[token = "\""]
     StartString,
+
     #[regex = r"\p{White_Space}"]
     WhiteSpace,
 }
@@ -20,17 +22,22 @@ enum Outer {
 enum Inner {
     #[end]
     End,
+
     #[error]
     Error,
 
     #[regex = r#"[^\\"]+"#]
     Text,
+
     #[token = "\\n"]
     EscapedNewline,
+
     #[regex = r"\\u\{[^}]*\}"]
     EscapedCodepoint,
+
     #[token = r#"\""#]
     EscapedQuote,
+
     #[token = "\""]
     EndString,
 }
@@ -47,12 +54,16 @@ fn main() {
     let mut inner = outer.advance_as::<Inner>();
     assert_eq!(inner.token, Inner::Text);
     inner.advance();
+
     assert_eq!(inner.token, Inner::EscapedCodepoint);
     inner.advance();
+
     assert_eq!(inner.token, Inner::Text);
     inner.advance();
+
     assert_eq!(inner.token, Inner::EscapedNewline);
     inner.advance();
+
     assert_eq!(inner.token, Inner::EndString);
 
     // We've exited the string, parser returns to outer lexer

--- a/tests/tests/properties.rs
+++ b/tests/tests/properties.rs
@@ -1,6 +1,4 @@
-use logos::Logos;
 use logos_derive::Logos;
-use std::ops::Range;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
 enum Token {
@@ -20,22 +18,8 @@ enum Token {
     Cyrillic,
 }
 
-fn assert_lex<'a, Source>(source: Source, tokens: &[(Token, Source::Slice, Range<usize>)])
-where
-    Source: logos::Source<'a>,
-{
-    let mut lex = Token::lexer(source);
-
-    for tuple in tokens {
-        assert_eq!(&(lex.token, lex.slice(), lex.range()), tuple);
-
-        lex.advance();
-    }
-
-    assert_eq!(lex.token, Token::End);
-}
-
 mod properties {
+    use tests::assert_lex;
     use super::*;
 
     #[test]

--- a/tests/tests/simple.rs
+++ b/tests/tests/simple.rs
@@ -1,6 +1,5 @@
-use logos::{Logos, Extras, Lexer};
+use logos::{Extras, Lexer};
 use logos_derive::Logos;
-use std::ops::Range;
 
 #[derive(Default)]
 struct MockExtras {
@@ -124,22 +123,9 @@ enum Token {
     FatArrow,
 }
 
-fn assert_lex<'a, Source>(source: Source, tokens: &[(Token, Source::Slice, Range<usize>)])
-where
-    Source: logos::Source<'a>,
-{
-    let mut lex = Token::lexer(source);
-
-    for tuple in tokens {
-        assert_eq!(&(lex.token, lex.slice(), lex.range()), tuple);
-
-        lex.advance();
-    }
-
-    assert_eq!(lex.token, Token::End);
-}
-
 mod simple {
+    use logos::Logos;
+    use tests::assert_lex;
     use super::*;
 
     #[test]

--- a/tests/tests/simple.rs
+++ b/tests/tests/simple.rs
@@ -48,7 +48,7 @@ enum Token {
     #[regex = "[a-zA-Z$_][a-zA-Z0-9$_]*"]
     Identifier,
 
-    #[regex = "[1-9][0-9]*"]
+    #[regex = "[1-9][0-9]*|0"]
     #[callback = "count_numbers"]
     Number,
 
@@ -229,7 +229,7 @@ mod simple {
     #[test]
     fn numbers() {
         assert_lex("0 1 2 3 4 10 42 1337", &[
-            (Token::Error, "0", 0..1),
+            (Token::Number, "0", 0..1),
             (Token::Number, "1", 2..3),
             (Token::Number, "2", 4..5),
             (Token::Number, "3", 6..7),
@@ -261,8 +261,10 @@ mod simple {
     #[test]
     fn invalid_hex_and_binary() {
         assert_lex("0x 0b", &[
-            (Token::Error, "0x", 0..2),
-            (Token::Error, "0b", 3..5),
+            (Token::Number, "0", 0..1),
+            (Token::Identifier, "x", 1..2),
+            (Token::Number, "0", 3..4),
+            (Token::Identifier, "b", 4..5),
         ]);
     }
 

--- a/tests/tests/trivia.rs
+++ b/tests/tests/trivia.rs
@@ -1,0 +1,29 @@
+use logos_derive::Logos;
+
+#[derive(Logos, Debug, Clone, Copy, PartialEq)]
+#[logos(trivia = "[a-f]")]
+enum Token {
+    #[error]
+    Error,
+
+    #[end]
+    End,
+
+    #[regex = "[0-9]+"]
+    Number,
+}
+
+mod trivia {
+    use tests::assert_lex;
+    use super::*;
+
+    #[test]
+    fn abcdef_trivia() {
+        assert_lex("abc12345def67890 afx", &[
+            (Token::Number, "12345", 3..8),
+            (Token::Number, "67890", 11..16),
+            (Token::Error, " ", 16..17),
+            (Token::Error, "x", 19..20),
+        ]);
+    }
+}

--- a/tests/tests/whitespace.rs
+++ b/tests/tests/whitespace.rs
@@ -1,0 +1,28 @@
+use logos_derive::Logos;
+
+#[derive(Logos, Debug, Clone, Copy, PartialEq)]
+#[logos(trivia = r"\p{Whitespace}")]
+enum Token {
+    #[error]
+    Error,
+
+    #[end]
+    End,
+
+    #[regex = "[0-9]+"]
+    Number,
+}
+
+mod trivia {
+    use tests::assert_lex;
+    use super::*;
+
+    #[test]
+    fn abcdef_trivia() {
+        assert_lex("   12345\u{2029}67890\t  x ", &[
+            (Token::Number, "12345", 3..8),
+            (Token::Number, "67890", 11..16),
+            (Token::Error, "x", 19..20),
+        ]);
+    }
+}

--- a/tests/tests/whitespace.rs
+++ b/tests/tests/whitespace.rs
@@ -13,7 +13,7 @@ enum Token {
     Number,
 }
 
-mod trivia {
+mod whitespace {
     use tests::assert_lex;
     use super::*;
 


### PR DESCRIPTION
+ Removed `NulTermStr` support and all special casing around the `0x00` bytes (closes #44, relevant to #15). `0x00` is now considered to be whitespace by default.
+ Started working on some more performance improvements that counterbalance the bound-check-less lexing that `NulTermStr` provided. There is definitely room for improvement with SIMD.

TODOS:

+ [x] Rename `ByteArray` trait to something else, since it's also implemented for `u8`.
+ [x] Keep track of how many bytes where consumed when entering a `Maybe` fork _on compile time_ and ~insert appropriate backtracks on failed matches~ **perform lookaheads until the branch becomes unambiguous** (closes #54).
+ [x] Allow for byte-array token and allow for non-unicode regex definitions, ~auto panic~ **fail to compile** when reading from `&str` if used  (Closes #15).
+ [x] Allow to change the default whitespace behavior (closes #21, relevant to #42).
+ ~De-duplicate repeated branches into function calls, rely on LLVM instead to figure out where inlining is a good idea and where it would blow up instruction cache.~ Will do later, because this PR is big enough as it is already.
+ ~Pack up to 8 lookup tables together into `[u8; 256]` instead of `[bool; 256]`, use bit masks to match the correct bit. Should have no effect on performance but help reduce the size of the generated binary.~ Shouldn't be necessary yet, and there are better workarounds.