### PR TITLE
Container lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,14 +34,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "logos"
-version = "0.11.0-rc4"
+version = "0.11.0-rc5"
 dependencies = [
- "logos-derive 0.11.0-rc4",
+ "logos-derive 0.11.0-rc5",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.11.0-rc4"
+version = "0.11.0-rc5"
 dependencies = [
  "beef 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -110,8 +110,8 @@ dependencies = [
 name = "tests"
 version = "0.0.0"
 dependencies = [
- "logos 0.11.0-rc4",
- "logos-derive 0.11.0-rc4",
+ "logos 0.11.0-rc5",
+ "logos-derive 0.11.0-rc5",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -122,14 +122,16 @@ fn main() {
 
 Logos can handle callbacks with following return types:
 
-| Return type     | Produces                                           |
-|-----------------|----------------------------------------------------|
-| `()`            | `Token::Unit`                                      |
-| `bool`          | `Token::Unit` **or** `<Token as Logos>::ERROR`     |
-| `Result<(), _>` | `Token::Unit` **or** `<Token as Logos>::ERROR`     |
-| `T`             | `Token::Value(T)`                                  |
-| `Option<T>`     | `Token::Value(T)` **or** `<Token as Logos>::ERROR` |
-| `Result<T, _>`  | `Token::Value(T)` **or** `<Token as Logos>::ERROR` |
+| Return type                       | Produces                                           |
+|-----------------------------------|----------------------------------------------------|
+| `()`                              | `Token::Unit`                                      |
+| `bool`                            | `Token::Unit` **or** `<Token as Logos>::ERROR`     |
+| `Result<(), _>`                   | `Token::Unit` **or** `<Token as Logos>::ERROR`     |
+| `T`                               | `Token::Value(T)`                                  |
+| `Option<T>`                       | `Token::Value(T)` **or** `<Token as Logos>::ERROR` |
+| `Result<T, _>`                    | `Token::Value(T)` **or** `<Token as Logos>::ERROR` |
+| `Skip`]                           | _skips matched input_                              |
+| `Filter<T>`]                      | `Token::Value(T)` **or** _skips matched input_     |
 
 Callbacks can be also used to do perform more specialized lexing in place
 where regular expressions are too limiting. For specifics look at

--- a/logos-derive/Cargo.toml
+++ b/logos-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logos-derive"
-version = "0.11.0-rc4"
+version = "0.11.0-rc5"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 license = "MIT OR Apache-2.0"
 description = "Create ridiculously fast Lexers"

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -25,7 +25,7 @@ use beef::lean::Cow;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
-use syn::{Ident, Fields, ItemEnum, Attribute, GenericParam, Lifetime, Type};
+use syn::{Ident, Fields, ItemEnum, Attribute, GenericParam};
 use syn::spanned::Spanned;
 
 enum Mode {
@@ -135,14 +135,7 @@ pub fn logos(input: TokenStream) -> TokenStream {
                     ).span(fields.span()))
                 }
 
-                let mut field = fields.unnamed.first().expect("Already checked len; qed").ty.clone();
-
-                // Replacing the lifetime should be done in the generator
-                if let Type::Reference(ref mut typeref) = field {
-                    let span = typeref.lifetime.as_ref().map(|lt| lt.span()).unwrap_or_else(|| Span::call_site());
-
-                    typeref.lifetime = Some(Lifetime::new("'s", span));
-                }
+                let field = fields.unnamed.first().expect("Already checked len; qed").ty.clone();
 
                 Some(field)
             }

--- a/logos/Cargo.toml
+++ b/logos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logos"
-version = "0.11.0-rc4"
+version = "0.11.0-rc5"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 license = "MIT OR Apache-2.0"
 description = "Create ridiculously fast Lexers"
@@ -12,7 +12,7 @@ readme = "../README.md"
 edition = "2018"
 
 [dependencies]
-logos-derive = { version = "0.11.0-rc4", optional = true }
+logos-derive = { version = "0.11.0-rc5", optional = true }
 
 [features]
 default = ["export_derive", "std"]

--- a/logos/src/internal.rs
+++ b/logos/src/internal.rs
@@ -1,5 +1,5 @@
 use crate::source::Chunk;
-use crate::{Logos, Lexer, Skip};
+use crate::{Logos, Lexer, Skip, Filter};
 
 /// Trait used by the functions contained in the `Lexicon`.
 ///
@@ -103,5 +103,21 @@ impl<'s, T: Logos<'s>> CallbackResult<'s, (), T> for Skip {
     {
         lex.trivia();
         T::lex(lex);
+    }
+}
+
+impl<'s, P, T: Logos<'s>> CallbackResult<'s, P, T> for Filter<P> {
+    #[inline]
+    fn construct<Constructor>(self, c: Constructor, lex: &mut Lexer<'s, T>)
+    where
+        Constructor: Fn(P) -> T,
+    {
+        match self {
+            Filter::Emit(product) => lex.set(c(product)),
+            Filter::Skip => {
+                lex.trivia();
+                T::lex(lex);
+            }
+        }
     }
 }

--- a/tests/tests/callbacks.rs
+++ b/tests/tests/callbacks.rs
@@ -36,6 +36,43 @@ mod data {
     }
 }
 
+mod nested_lifetime {
+    use super::*;
+    use std::borrow::Cow;
+
+    #[derive(Logos, Debug, PartialEq)]
+    enum Token<'a> {
+        #[error]
+        Error,
+
+        #[regex(r"[0-9]+", |lex| {
+            let slice = lex.slice();
+
+            slice.parse::<u64>().map(|n| {
+                (slice, n)
+            })
+        })]
+        Integer((&'a str, u64)),
+
+        #[regex(r"[a-z]+", |lex| Cow::Borrowed(lex.slice()))]
+        Text(Cow<'a, str>)
+    }
+
+    #[test]
+    fn supplement_lifetime_in_types() {
+        let tokens: Vec<_> = Token::lexer("123 hello 42").collect();
+
+        assert_eq!(
+            tokens,
+            &[
+                Token::Integer(("123", 123)),
+                Token::Text(Cow::Borrowed("hello")),
+                Token::Integer(("42", 42)),
+            ],
+        );
+    }
+}
+
 mod rust {
     use super::*;
 


### PR DESCRIPTION
+ Allows for enum variants to have types with lifetimes other than plain references, such as `(_, &'a str)` or `Cow<'a, str>` (closes #118).
+ Introduced `Filter<T>` enum, with `Emit(T)` and `Skip` variants, which allows callbacks to either produce a token with value `T`, or skip current match altogether (also #118).