### PR TITLE
Handle type parameters

### DIFF
--- a/logos-derive/src/error.rs
+++ b/logos-derive/src/error.rs
@@ -1,10 +1,52 @@
 use std::fmt;
 
 use beef::lean::Cow;
+use quote::quote;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote_spanned, ToTokens, TokenStreamExt};
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+pub struct Errors {
+    collected: Vec<SpannedError>,
+}
+
+impl Errors {
+    pub fn new() -> Self {
+        Errors {
+            collected: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, err: SpannedError) {
+        self.collected.push(err);
+    }
+
+    pub fn err<M>(&mut self, message: M, span: Span) -> &mut Self
+    where
+        M: Into<Cow<'static, str>>,
+    {
+        self.collected.push(SpannedError {
+            message: message.into(),
+            span,
+        });
+
+        self
+    }
+
+    pub fn render(self) -> Option<TokenStream> {
+        let errors = self.collected;
+
+        match errors.len() {
+            0 => None,
+            _ => Some(quote! {
+                fn _logos_derive_compile_errors() {
+                    #(#errors)*
+                }
+            })
+        }
+    }
+}
 
 pub struct Error(Cow<'static, str>);
 

--- a/logos-derive/src/error.rs
+++ b/logos-derive/src/error.rs
@@ -11,13 +11,15 @@ pub struct Errors {
     collected: Vec<SpannedError>,
 }
 
-impl Errors {
-    pub fn new() -> Self {
+impl Default for Errors {
+    fn default() -> Self {
         Errors {
             collected: Vec::new(),
         }
     }
+}
 
+impl Errors {
     pub fn push(&mut self, err: SpannedError) {
         self.collected.push(err);
     }

--- a/logos-derive/src/generator/leaf.rs
+++ b/logos-derive/src/generator/leaf.rs
@@ -1,5 +1,4 @@
-use proc_macro2::{TokenStream, Span};
-use syn::{Lifetime, Type};
+use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::leaf::{Leaf, Callback};
@@ -14,11 +13,7 @@ impl<'a> Generator<'a> {
         let this = self.this;
 
         let (ty, constructor) = match leaf.field.clone() {
-            Some(mut ty) => {
-                replace_lifetimes(&mut ty);
-
-                (quote!(#ty), quote!(#name::#ident))
-            },
+            Some(ty) => (quote!(#ty), quote!(#name::#ident)),
             None => (quote!(()), quote!(|()| #name::#ident)),
         };
 
@@ -47,50 +42,5 @@ impl<'a> Generator<'a> {
                 lex.set(token);
             },
         }
-    }
-}
-
-fn replace_lifetimes(ty: &mut Type) {
-    use syn::{PathArguments, GenericArgument};
-    use syn::spanned::Spanned;
-
-    match ty {
-        Type::Array(array) => replace_lifetimes(&mut array.elem),
-        Type::Group(group) => replace_lifetimes(&mut group.elem),
-        Type::Paren(paren) => replace_lifetimes(&mut paren.elem),
-        Type::Path(p) => {
-            p.path.segments
-                .iter_mut()
-                .filter_map(|segment| match &mut segment.arguments {
-                    PathArguments::AngleBracketed(ab) => Some(ab),
-                    _ => None,
-                })
-                .flat_map(|ab| ab.args.iter_mut())
-                .for_each(|arg| {
-                    match arg {
-                        GenericArgument::Lifetime(lt) => {
-                            *lt = Lifetime::new("'s", lt.span());
-                        },
-                        GenericArgument::Type(ty) => {
-                            replace_lifetimes(ty);
-                        },
-                        GenericArgument::Binding(bind) => {
-                            replace_lifetimes(&mut bind.ty);
-                        },
-                        _ => (),
-                    }
-                });
-        },
-        Type::Reference(r) => {
-            let span = match r.lifetime.take() {
-                Some(lt) => lt.span(),
-                None => Span::call_site(),
-            };
-
-            r.lifetime = Some(Lifetime::new("'s", span));
-        },
-        Type::Slice(slice) => replace_lifetimes(&mut slice.elem),
-        Type::Tuple(tuple) => tuple.elems.iter_mut().for_each(replace_lifetimes),
-        _ => (),
     }
 }

--- a/logos-derive/src/parser.rs
+++ b/logos-derive/src/parser.rs
@@ -1,0 +1,88 @@
+use beef::lean::Cow;
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{Attribute, spanned::Spanned};
+
+use crate::util;
+use crate::error::Errors;
+use crate::parsers::{AttributeParser, Nested, NestedValue};
+
+pub struct Parser {
+    pub errors: Errors,
+    extras: Option<TokenStream>,
+}
+
+impl Parser {
+    pub fn new() -> Self {
+        Parser {
+            errors: Errors::new(),
+            extras: None,
+        }
+    }
+
+    pub fn extras(&mut self) -> TokenStream {
+        self.extras.take().unwrap_or_else(|| quote!(()))
+    }
+
+    pub fn try_parse_logos(&mut self, attr: &Attribute) {
+        if !attr.path.is_ident("logos") {
+            return;
+        }
+
+        let nested = util::read_attr("logos", attr, &mut self.errors);
+
+        for nested in AttributeParser::new(nested.clone()) {
+            let (name, value) = match nested {
+                Nested::Named(name, value) => (name, value),
+                Nested::Unexpected(unexpected) => {
+                    self.err("Unexpected tokens in attribute", unexpected.span());
+                    continue;
+                },
+                Nested::Unnamed(unnamed) => {
+                    self.err("Expected a named nested attribute", unnamed.span());
+                    continue;
+                },
+            };
+
+            match (name.to_string().as_str(), value) {
+                ("extras", NestedValue::Assign(value)) => {
+                    let span = value.span();
+
+                    if let Some(previous) = self.extras.replace(value) {
+                        self.err("Extras can be defined only once", span)
+                            .err("Previous definition here", previous.span());
+                    }
+                },
+                ("extras", _) => {
+                    self.err("Expected = after this token", name.span());
+                }
+                ("type", _) => (),
+                ("trivia", _) => {
+                    // TODO: Remove in future versions
+                    self.err(
+                        "\
+                        trivia are no longer supported.\n\n\
+
+                        For help with migration see release notes: \
+                        https://github.com/maciejhirsz/logos/releases\
+                        ",
+                        name.span(),
+                    );
+                },
+                (unknown, _) => {
+                    self.err(
+                        format!("Unknown nested attribute {}", unknown),
+                        name.span(),
+                    );
+                }
+            }
+        }
+    }
+
+    pub fn err<M>(&mut self, message: M, span: Span) -> &mut Errors
+    where
+        M: Into<Cow<'static, str>>,
+    {
+        self.errors.err(message, span)
+    }
+}

--- a/logos-derive/src/parser.rs
+++ b/logos-derive/src/parser.rs
@@ -1,27 +1,44 @@
 use beef::lean::Cow;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{Attribute, spanned::Spanned};
+use syn::{Attribute, GenericParam, Type, spanned::Spanned};
 
 use crate::util;
 use crate::error::Errors;
 use crate::parsers::{AttributeParser, Nested, NestedValue};
+use crate::type_params::{TypeParams, replace_lifetimes};
 
+#[derive(Default)]
 pub struct Parser {
     pub errors: Errors,
     extras: Option<TokenStream>,
+    types: TypeParams,
 }
 
 impl Parser {
-    pub fn new() -> Self {
-        Parser {
-            errors: Errors::new(),
-            extras: None,
+    pub fn extras(&mut self) -> TokenStream {
+        self.extras.take().unwrap_or_else(|| quote!(()))
+    }
+
+    pub fn parse_generic(&mut self, param: GenericParam) {
+        match param {
+            GenericParam::Lifetime(lt) => {
+                self.types.explicit_lifetime(lt, &mut self.errors);
+            },
+            GenericParam::Type(ty) => {
+                self.types.add(ty.ident);
+            },
+            GenericParam::Const(c) => {
+                self.err(
+                    "Logos doesn't support const generics.",
+                    c.span(),
+                );
+            },
         }
     }
 
-    pub fn extras(&mut self) -> TokenStream {
-        self.extras.take().unwrap_or_else(|| quote!(()))
+    pub fn generics(&mut self) -> Option<TokenStream> {
+        self.types.generics(&mut self.errors)
     }
 
     pub fn try_parse_logos(&mut self, attr: &Attribute) {
@@ -31,7 +48,7 @@ impl Parser {
 
         let nested = util::read_attr("logos", attr, &mut self.errors);
 
-        for nested in AttributeParser::new(nested.clone()) {
+        for nested in AttributeParser::new(nested) {
             let (name, value) = match nested {
                 Nested::Named(name, value) => (name, value),
                 Nested::Unexpected(unexpected) => {
@@ -54,9 +71,14 @@ impl Parser {
                     }
                 },
                 ("extras", _) => {
-                    self.err("Expected = after this token", name.span());
+                    self.err("Expected: extras = SomeType", name.span());
                 }
-                ("type", _) => (),
+                ("type", NestedValue::KeywordAssign(generic, ty)) => {
+                    self.types.set(generic, ty, &mut self.errors);
+                },
+                ("type", _) => {
+                    self.err("Expected: type T = SomeType", name.span());
+                },
                 ("trivia", _) => {
                     // TODO: Remove in future versions
                     self.err(
@@ -71,12 +93,32 @@ impl Parser {
                 },
                 (unknown, _) => {
                     self.err(
-                        format!("Unknown nested attribute {}", unknown),
+                        format!("Unknown nested attribute: {}", unknown),
                         name.span(),
                     );
                 }
             }
         }
+    }
+
+    /// Checks if `ty` is a declared generic param, if so replaces it
+    /// with a concrete type defined using #[logos(type T = Type)]
+    ///
+    /// If no matching generic param is found, all lifetimes are fixed
+    /// to the source lifetime
+    pub fn get_type(&self, mut ty: Type) -> Type {
+        if let Type::Path(tp) = &ty {
+            if tp.qself.is_some() {
+                return ty;
+            }
+
+            if let Some(substitue) = self.types.find(&tp.path) {
+                return substitue;
+            }
+        }
+
+        replace_lifetimes(&mut ty);
+        ty
     }
 
     pub fn err<M>(&mut self, message: M, span: Span) -> &mut Errors

--- a/logos-derive/src/parsers.rs
+++ b/logos-derive/src/parsers.rs
@@ -1,0 +1,136 @@
+use proc_macro2::token_stream::IntoIter as TokenIter;
+use proc_macro2::{Ident, TokenTree, TokenStream};
+
+use crate::util::is_punct;
+
+pub enum NestedValue {
+    /// `name`
+    None,
+    /// `name = ...`
+    Assign(TokenStream),
+    /// `name(...)`
+    Group(TokenStream),
+    /// `name ident = ...`
+    KeywordAssign(Ident, TokenStream),
+}
+
+pub enum Nested {
+    /// Unnamed nested attribute, such as a string,
+    /// callback closure, or a lone path
+    ///
+    /// Note: a lone ident will be Named with no value instead
+    Unnamed(TokenStream),
+    /// Named: name ...
+    Named(Ident, NestedValue),
+    /// Unexpected token,
+    Unexpected(TokenStream),
+}
+
+pub struct AttributeParser {
+    inner: TokenIter,
+}
+
+pub struct Empty;
+
+impl From<Empty> for TokenStream {
+    fn from(_: Empty) -> TokenStream {
+        TokenStream::new()
+    }
+}
+
+impl AttributeParser {
+    pub fn new(stream: TokenStream) -> Self {
+        AttributeParser {
+            inner: stream.into_iter()
+        }
+    }
+
+    fn next_tt(&mut self) -> Option<TokenTree> {
+        match self.inner.next() {
+            Some(tt) if is_punct(&tt, ',') => None,
+            next => next,
+        }
+    }
+
+    fn collect_tail<T>(&mut self, first: T) -> TokenStream
+    where
+        T: Into<TokenStream>,
+    {
+        let mut out = first.into();
+
+        while let Some(tt) = self.next_tt() {
+            out.extend(Some(tt));
+        }
+
+        out
+    }
+
+    fn parse_unnamed(&mut self, first: Ident, next: TokenTree) -> Nested {
+        let mut out = TokenStream::from(TokenTree::Ident(first));
+
+        out.extend(self.collect_tail(next));
+
+        Nested::Unnamed(out)
+    }
+
+    fn parse_assign(&mut self, name: Ident) -> Nested {
+        let value = self.collect_tail(Empty);
+
+        Nested::Named(name, NestedValue::Assign(value))
+    }
+
+    fn parse_group(&mut self, name: Ident, group: TokenStream) -> Nested {
+        let error = self.collect_tail(Empty);
+
+        if error.is_empty() {
+            Nested::Named(name, NestedValue::Group(group))
+        } else {
+            Nested::Unexpected(error.into())
+        }
+    }
+
+    fn parse_keyword(&mut self, keyword: Ident, name: Ident) -> Nested {
+        let error = match self.next_tt() {
+            Some(tt) if is_punct(&tt, '=') => None,
+            next => next,
+        };
+
+        match error {
+            Some(error) => {
+                let error = self.collect_tail(error);
+
+                Nested::Unexpected(error)
+            },
+            None => {
+                let value = self.collect_tail(Empty);
+
+                Nested::Named(keyword, NestedValue::KeywordAssign(name, value))
+            },
+        }
+    }
+}
+
+impl Iterator for AttributeParser {
+    type Item = Nested;
+
+    fn next(&mut self) -> Option<Nested> {
+        let first = self.inner.next()?;
+
+        let name = match first {
+            TokenTree::Ident(ident) => ident,
+            tt => {
+                let stream = self.collect_tail(tt);
+
+                return Some(Nested::Unnamed(stream));
+            }
+        };
+
+        match self.next_tt() {
+            Some(tt) if is_punct(&tt, '=') => Some(self.parse_assign(name)),
+            Some(TokenTree::Group(group)) => Some(self.parse_group(name, group.stream())),
+            Some(TokenTree::Ident(next)) => Some(self.parse_keyword(name, next)),
+            Some(next) => Some(self.parse_unnamed(name, next)),
+            None => Some(Nested::Named(name, NestedValue::None)),
+        }
+    }
+}

--- a/logos-derive/src/type_params.rs
+++ b/logos-derive/src/type_params.rs
@@ -1,0 +1,50 @@
+use proc_macro2::{Ident, TokenStream};
+use syn::LifetimeDef;
+use syn::spanned::Spanned;
+use quote::quote;
+
+use crate::error::{Error, SpannedError};
+
+#[derive(Default)]
+pub struct TypeParams {
+    lifetime: bool,
+    type_params: Vec<Ident>,
+}
+
+impl TypeParams {
+    pub fn explicit_lifetime(&mut self, lt: LifetimeDef, errors: &mut Vec<SpannedError>) {
+        if self.lifetime {
+            let span = lt.span();
+
+            errors.push(Error::new("Logos types can only have one lifetime can be set").span(span));
+        }
+
+        self.lifetime = true;
+    }
+
+    pub fn add_param(&mut self, param: Ident) {
+        self.type_params.push(param);
+    }
+
+    pub fn generics(&self, errors: &mut Vec<SpannedError>) -> Option<TokenStream> {
+        if !self.lifetime && self.type_params.is_empty() {
+            return None;
+        }
+
+        for ty in self.type_params.iter() {
+            let err = format!(
+                "Generic type parameter without a concrete type\n\n\
+
+                Define a concrete type Logos can use: #[logos(for {} = Type)]",
+                ty
+            );
+            errors.push(Error::new(err).span(ty.span()));
+        }
+
+        if self.lifetime {
+            Some(quote!(<'s>))
+        } else {
+            None
+        }
+    }
+}

--- a/logos-derive/src/type_params.rs
+++ b/logos-derive/src/type_params.rs
@@ -1,5 +1,5 @@
-use proc_macro2::{Ident, TokenStream};
-use syn::LifetimeDef;
+use proc_macro2::{Ident, TokenStream, Span};
+use syn::{Type, Path, Lifetime, LifetimeDef};
 use syn::spanned::Spanned;
 use quote::quote;
 
@@ -8,7 +8,7 @@ use crate::error::Errors;
 #[derive(Default)]
 pub struct TypeParams {
     lifetime: bool,
-    type_params: Vec<Ident>,
+    type_params: Vec<(Ident, Option<Type>)>,
 }
 
 impl TypeParams {
@@ -22,31 +22,128 @@ impl TypeParams {
         self.lifetime = true;
     }
 
-    pub fn add_param(&mut self, param: Ident) {
-        self.type_params.push(param);
+    pub fn add(&mut self, param: Ident) {
+        self.type_params.push((param, None));
     }
 
-    pub fn generics(&self, errors: &mut Errors) -> Option<TokenStream> {
+    pub fn set(&mut self, param: Ident, ty: TokenStream, errors: &mut Errors) {
+        let ty = match syn::parse2::<Type>(ty) {
+            Ok(mut ty) => {
+                replace_lifetimes(&mut ty);
+                ty
+            },
+            Err(err) => {
+                errors.err(err.to_string(), err.span());
+                return;
+            },
+        };
+
+        match self.type_params.iter_mut().find(|(name, _)| *name == param) {
+            Some((_, slot)) => {
+                if let Some(previous) = slot.replace(ty) {
+                    errors
+                        .err(
+                            format!("{} can only have one type assigned to it", param),
+                            param.span(),
+                        )
+                        .err("Previously assigned here", previous.span());
+                }
+            },
+            None => {
+                errors.err(
+                    format!("{} is not a declared type parameter", param),
+                    param.span(),
+                );
+            }
+        }
+    }
+
+    pub fn find(&self, path: &Path) -> Option<Type> {
+        for (ident, ty) in &self.type_params {
+            if path.is_ident(ident) {
+                return ty.clone();
+            }
+        }
+
+        None
+    }
+
+    pub fn generics(&mut self, errors: &mut Errors) -> Option<TokenStream> {
         if !self.lifetime && self.type_params.is_empty() {
             return None;
         }
 
-        for ty in self.type_params.iter() {
-            errors.err(
-                format!(
-                    "Generic type parameter without a concrete type\n\n\
-
-                    Define a concrete type Logos can use: #[logos(type {} = Type)]",
-                    ty,
-                ),
-                ty.span(),
-            );
-        }
+        let mut generics = Vec::new();
 
         if self.lifetime {
-            Some(quote!(<'s>))
-        } else {
-            None
+            generics.push(quote!('s));
         }
+
+        for (ty, replace) in self.type_params.drain(..) {
+            match replace {
+                Some(ty) => generics.push(quote!(#ty)),
+                None => {
+                    errors.err(
+                        format!(
+                            "Generic type parameter without a concrete type\n\n\
+
+                            Define a concrete type Logos can use: #[logos(type {} = Type)]",
+                            ty,
+                        ),
+                        ty.span(),
+                    );
+                }
+            }
+        }
+
+        if generics.is_empty() {
+            None
+        } else {
+            Some(quote!(<#(#generics),*>))
+        }
+    }
+}
+
+pub fn replace_lifetimes(ty: &mut Type) {
+    use syn::{PathArguments, GenericArgument};
+
+    match ty {
+        Type::Array(array) => replace_lifetimes(&mut array.elem),
+        Type::Group(group) => replace_lifetimes(&mut group.elem),
+        Type::Paren(paren) => replace_lifetimes(&mut paren.elem),
+        Type::Path(p) => {
+            p.path.segments
+                .iter_mut()
+                .filter_map(|segment| match &mut segment.arguments {
+                    PathArguments::AngleBracketed(ab) => Some(ab),
+                    _ => None,
+                })
+                .flat_map(|ab| ab.args.iter_mut())
+                .for_each(|arg| {
+                    match arg {
+                        GenericArgument::Lifetime(lt) => {
+                            *lt = Lifetime::new("'s", lt.span());
+                        },
+                        GenericArgument::Type(ty) => {
+                            replace_lifetimes(ty);
+                        },
+                        GenericArgument::Binding(bind) => {
+                            replace_lifetimes(&mut bind.ty);
+                        },
+                        _ => (),
+                    }
+                });
+        },
+        Type::Reference(r) => {
+            let span = match r.lifetime.take() {
+                Some(lt) => lt.span(),
+                None => Span::call_site(),
+            };
+
+            r.lifetime = Some(Lifetime::new("'s", span));
+        },
+        Type::Slice(slice) => replace_lifetimes(&mut slice.elem),
+        Type::Tuple(tuple) => tuple.elems.iter_mut().for_each(replace_lifetimes),
+        _ => (),
     }
 }

--- a/logos-derive/src/util.rs
+++ b/logos-derive/src/util.rs
@@ -99,10 +99,10 @@ impl<V: Value> Value for Definition<V> {
     }
 }
 
-pub fn read_attr(name: &str, attr: &Attribute) -> Result<Option<TokenStream>> {
+pub fn read_attr(name: &str, attr: &Attribute) -> Result<TokenStream> {
     let stream = attr_fields(name, attr.tokens.clone(), attr.span())?;
 
-    Ok(Some(stream))
+    Ok(stream)
 }
 
 fn attr_fields<Tokens>(name: &str, stream: Tokens, span: Span) -> Result<TokenStream>
@@ -140,11 +140,13 @@ where
     }
 }
 
-pub fn value_from_attr<V>(name: &str, attr: &Attribute) -> Result<Option<V>>
+pub fn value_from_attr<V>(name: &str, attr: &Attribute) -> Result<V>
 where
     V: Value,
 {
-    read_attr(name, attr)?.map(parse_value).transpose()
+    let stream = attr_fields(name, attr.tokens.clone(), attr.span())?;
+
+    parse_value(stream)
 }
 
 pub fn value_from_nested(name: &str, nested: &TokenStream) -> Result<Option<Ident>> {

--- a/logos-derive/src/util.rs
+++ b/logos-derive/src/util.rs
@@ -100,9 +100,17 @@ impl<V: Value> Value for Definition<V> {
 }
 
 pub fn read_attr(name: &str, attr: &Attribute) -> Result<TokenStream> {
-    let stream = attr_fields(name, attr.tokens.clone(), attr.span())?;
+    let mut tokens = attr.tokens.clone().into_iter();
 
-    Ok(stream)
+    match tokens.next() {
+        Some(TokenTree::Group(group)) => Ok(group.stream()),
+        _ => {
+            let err = format!("Expected #[{}(...)]", name);
+            let span = attr.span();
+
+            Err(Error::new(err).span(span))
+        }
+    }
 }
 
 fn attr_fields<Tokens>(name: &str, stream: Tokens, span: Span) -> Result<TokenStream>

--- a/tests/tests/edgecase.rs
+++ b/tests/tests/edgecase.rs
@@ -336,6 +336,7 @@ mod type_params {
     use logos::Logos;
 
     #[derive(Logos, Debug, PartialEq)]
+    #[logos(for S = &str)]
     enum Token<S> {
         #[error]
         Error,

--- a/tests/tests/edgecase.rs
+++ b/tests/tests/edgecase.rs
@@ -331,3 +331,22 @@ mod colors {
         );
     }
 }
+
+mod type_params {
+    use logos::Logos;
+
+    #[derive(Logos, Debug, PartialEq)]
+    enum Token<S> {
+        #[error]
+        Error,
+
+        #[regex("[0-9A-F][0-9A-F]a?")]
+        Ident(S),
+    }
+
+    #[test]
+    fn maybe_at_the_end() {
+        let mut lexer = Token::lexer("foo");
+        assert_eq!(lexer.next().unwrap(), Token::Ident("foo"));
+    }
+}

--- a/tests/tests/edgecase.rs
+++ b/tests/tests/edgecase.rs
@@ -336,7 +336,7 @@ mod type_params {
     use logos::Logos;
 
     #[derive(Logos, Debug, PartialEq)]
-    #[logos(for S = &str)]
+    #[logos(type S = &str)]
     enum Token<S> {
         #[error]
         Error,

--- a/tests/tests/edgecase.rs
+++ b/tests/tests/edgecase.rs
@@ -336,18 +336,33 @@ mod type_params {
     use logos::Logos;
 
     #[derive(Logos, Debug, PartialEq)]
-    #[logos(type S = &str)]
-    enum Token<S> {
+    #[logos(
+        type S = &str,
+        type N = u64,
+    )]
+    enum Token<S, N> {
+        #[regex(r"[ \n\t\f]+", logos::skip)]
         #[error]
         Error,
 
-        #[regex("[0-9A-F][0-9A-F]a?")]
+        #[regex("[a-z]+")]
         Ident(S),
+
+        #[regex("[0-9]+", |lex| lex.slice().parse())]
+        Number(N)
     }
 
     #[test]
     fn maybe_at_the_end() {
-        let mut lexer = Token::lexer("foo");
-        assert_eq!(lexer.next().unwrap(), Token::Ident("foo"));
+        let tokens: Vec<_> = Token::lexer("foo 42 bar").collect();
+
+        assert_eq!(
+            tokens,
+            &[
+                Token::Ident("foo"),
+                Token::Number(42u64),
+                Token::Ident("bar"),
+            ]
+        );
     }
 }


### PR DESCRIPTION
Deriving Logos on an enum with type parameters like so:

```rust
    #[derive(Logos, Debug, PartialEq)]
    enum Token<S, N> {
        #[regex(r"[ \n\t\f]+", logos::skip)]
        #[error]
        Error,

        #[regex("[a-z]+")]
        Ident(S),

        #[regex("[0-9]+", |lex| lex.slice().parse())]
        Number(N)
    }
```

Will now produce following errors:

```
error: Generic type parameter without a concrete type

Define a concrete type Logos can use: #[logos(type S = Type)]
   --> tests/tests/edgecase.rs:339:16
    |
339 |     enum Token<S, N> {
    |                ^

error: Generic type parameter without a concrete type

Define a concrete type Logos can use: #[logos(type N = Type)]
   --> tests/tests/edgecase.rs:339:19
    |
339 |     enum Token<S, N> {
    |                   ^
```

Defining concrete types for type parameters will make it work:

```rust
    #[derive(Logos, Debug, PartialEq)]
    #[logos(
        type S = &str,
        type N = u64,
    )]
    enum Token<S, N> {
```

All reference types (like `&str` above) will automatically use the lifetime of the source.

This PR also introduces a new `Parser` struct that handles attribute parsing, for now it's only used to handle the `#[logos(...)]` attribute.

Closes #123 