### PR TITLE
fix: Replace type parameters nested inside types

### DIFF
--- a/logos-derive/src/parser/mod.rs
+++ b/logos-derive/src/parser/mod.rs
@@ -14,7 +14,7 @@ mod type_params;
 
 pub use self::definition::{Definition, Literal};
 use self::nested::{AttributeParser, Nested, NestedValue};
-use self::type_params::{TypeParams, replace_types, replace_lifetime};
+use self::type_params::{TypeParams, traverse_type, replace_lifetime};
 
 #[derive(Default)]
 pub struct Parser {
@@ -241,7 +241,7 @@ impl Parser {
     /// If no matching generic param is found, all lifetimes are fixed
     /// to the source lifetime
     pub fn get_type(&self, ty: &mut Type) -> TokenStream {
-        replace_types(ty, &mut |ty| {
+        traverse_type(ty, &mut |ty| {
             if let Type::Path(tp) = ty {
                 // Skip types that begin with `self::`
                 if tp.qself.is_none() {

--- a/logos-derive/src/parser/type_params.rs
+++ b/logos-derive/src/parser/type_params.rs
@@ -8,7 +8,7 @@ use crate::error::Errors;
 #[derive(Default)]
 pub struct TypeParams {
     lifetime: bool,
-    type_params: Vec<(Ident, Option<TokenStream>)>,
+    type_params: Vec<(Ident, Option<Type>)>,
 }
 
 impl TypeParams {
@@ -30,7 +30,7 @@ impl TypeParams {
         let ty = match syn::parse2::<Type>(ty) {
             Ok(mut ty) => {
                 replace_lifetimes(&mut ty);
-                quote!(#ty)
+                ty
             },
             Err(err) => {
                 errors.err(err.to_string(), err.span());
@@ -58,7 +58,7 @@ impl TypeParams {
         }
     }
 
-    pub fn find(&self, path: &Path) -> Option<TokenStream> {
+    pub fn find(&self, path: &Path) -> Option<Type> {
         for (ident, ty) in &self.type_params {
             if path.is_ident(ident) {
                 return ty.clone();
@@ -105,12 +105,13 @@ impl TypeParams {
 }
 
 pub fn replace_lifetimes(ty: &mut Type) {
+    replace_types(ty, &mut replace_lifetime)
+}
+
+pub fn replace_lifetime(ty: &mut Type) {
     use syn::{PathArguments, GenericArgument};
 
     match ty {
-        Type::Array(array) => replace_lifetimes(&mut array.elem),
-        Type::Group(group) => replace_lifetimes(&mut group.elem),
-        Type::Paren(paren) => replace_lifetimes(&mut paren.elem),
         Type::Path(p) => {
             p.path.segments
                 .iter_mut()
@@ -124,12 +125,6 @@ pub fn replace_lifetimes(ty: &mut Type) {
                         GenericArgument::Lifetime(lt) => {
                             *lt = Lifetime::new("'s", lt.span());
                         },
-                        GenericArgument::Type(ty) => {
-                            replace_lifetimes(ty);
-                        },
-                        GenericArgument::Binding(bind) => {
-                            replace_lifetimes(&mut bind.ty);
-                        },
                         _ => (),
                     }
                 });
@@ -142,8 +137,65 @@ pub fn replace_lifetimes(ty: &mut Type) {
 
             r.lifetime = Some(Lifetime::new("'s", span));
         },
-        Type::Slice(slice) => replace_lifetimes(&mut slice.elem),
-        Type::Tuple(tuple) => tuple.elems.iter_mut().for_each(replace_lifetimes),
         _ => (),
+    }
+}
+
+pub fn replace_types(ty: &mut Type, f: &mut impl FnMut(&mut Type)) {
+    f(ty);
+    match ty {
+        Type::Array(array) => replace_types(&mut array.elem, f),
+        Type::BareFn(bare_fn) => {
+            for input in &mut bare_fn.inputs {
+                replace_types(&mut input.ty, f);
+            }
+            if let syn::ReturnType::Type(_, ty) = &mut bare_fn.output {
+                replace_types(ty, f);
+            }
+        }
+        Type::Group(group) => replace_types(&mut group.elem, f),
+        Type::Paren(paren) => replace_types(&mut paren.elem, f),
+        Type::Path(path) => replace_path(&mut path.path, f),
+        Type::Ptr(p) => {
+            replace_types(&mut p.elem, f)
+        },
+        Type::Reference(r) => {
+            replace_types(&mut r.elem, f)
+        },
+        Type::Slice(slice) => replace_types(&mut slice.elem, f),
+        Type::TraitObject(object) => object.bounds.iter_mut().for_each(|bound| {
+            if let syn::TypeParamBound::Trait(trait_bound) = bound {
+                replace_path(&mut trait_bound.path, f);
+            }
+        }),
+        Type::Tuple(tuple) => tuple.elems.iter_mut().for_each(|elem| replace_types(elem, f)),
+        _ => (),
+    }
+}
+
+fn replace_path(path: &mut Path, f: &mut impl FnMut(&mut Type)) {
+    for segment in &mut path.segments {
+        match &mut segment.arguments {
+            syn::PathArguments::None => (),
+            syn::PathArguments::AngleBracketed(args) => for arg in &mut args.args {
+                match arg {
+                    syn::GenericArgument::Type(ty) => {
+                        replace_types(ty, f);
+                    },
+                    syn::GenericArgument::Binding(bind) => {
+                        replace_types(&mut bind.ty, f);
+                    },
+                    _ => (),
+                }
+            },
+            syn::PathArguments::Parenthesized(args) => {
+                for arg in &mut args.inputs {
+                    replace_types(arg, f);
+                }
+                if let syn::ReturnType::Type(_, ty) = &mut args.output {
+                    replace_types(ty, f);
+                }
+            }
+        }
     }
 }

--- a/tests/tests/edgecase.rs
+++ b/tests/tests/edgecase.rs
@@ -335,6 +335,9 @@ mod colors {
 mod type_params {
     use logos::Logos;
 
+    #[derive(Debug, PartialEq)]
+    struct Nested<S>(S);
+
     #[derive(Logos, Debug, PartialEq)]
     #[logos(
         type S = &str,
@@ -349,7 +352,10 @@ mod type_params {
         Ident(S),
 
         #[regex("[0-9]+", priority = 10, callback = |lex| lex.slice().parse())]
-        Number(N)
+        Number(N),
+
+        #[regex("nested", |lex| Nested(lex.slice()))]
+        Nested(Nested<S>),
     }
 
     #[test]


### PR DESCRIPTION
https://github.com/maciejhirsz/logos/pull/128 only replaced if the
parameter were a direct field in a variant. This extends it to work if
it is inside a tuple, argument to another type etc