### PR TITLE
Named subregex

### DIFF
--- a/logos-derive/src/parser/mod.rs
+++ b/logos-derive/src/parser/mod.rs
@@ -17,6 +17,7 @@ mod type_params;
 
 pub use self::definition::{Definition, Literal};
 use self::nested::{AttributeParser, Nested, NestedValue};
+pub use self::subpattern::Subpattern;
 use self::subpattern::SubpatternInput;
 use self::type_params::{replace_lifetime, traverse_type, TypeParams};
 

--- a/logos-derive/src/parser/subpattern.rs
+++ b/logos-derive/src/parser/subpattern.rs
@@ -58,14 +58,10 @@ impl Subpatterns {
             Literal::Bytes(b) => bytes_to_regex_string(b.value()),
         };
 
-        while i < pattern.len() {
-            if let Some(f) = pattern[i..].find("(?&") {
-                i += f;
-                pattern.replace_range(i..i + 3, "(?:");
-                i += 3;
-            } else {
-                break; // done!
-            }
+        while let Some(f) = pattern[i..].find("(?&") {
+            i += f;
+            pattern.replace_range(i..i + 3, "(?:");
+            i += 3;
 
             let subref_end = if let Some(f) = pattern[i..].find(')') {
                 i + f

--- a/logos-derive/src/parser/subpattern.rs
+++ b/logos-derive/src/parser/subpattern.rs
@@ -1,52 +1,118 @@
-use syn::parse::{Parse, ParseStream};
-use syn::punctuated::{Pair, Punctuated};
-use syn::{Ident, LitStr, MetaNameValue, Token};
+use proc_macro2::TokenStream;
+use syn::{Ident, LitByteStr, LitStr};
 
-use crate::error::{Error, Result};
+use crate::error::Errors;
 use crate::mir::Mir;
+use crate::parser::definition::{bytes_to_regex_string, Literal};
 
-pub struct SubpatternInput {
-    kvs: Punctuated<MetaNameValue, Token![,]>,
+#[derive(Default)]
+pub struct Subpatterns {
+    map: Vec<(Ident, Literal)>,
 }
 
-impl Parse for SubpatternInput {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        Ok(SubpatternInput {
-            kvs: Punctuated::parse_terminated(input)?,
-        })
-    }
-}
+impl Subpatterns {
+    pub fn add(&mut self, param: Ident, pattern: TokenStream, errors: &mut Errors) {
+        let lit = match syn::parse2::<Literal>(pattern) {
+            Ok(lit) => lit,
+            Err(e) => {
+                errors.err(e.to_string(), e.span());
+                return;
+            }
+        };
 
-impl SubpatternInput {
-    pub fn into_iter(self) -> impl Iterator<Item = MetaNameValue> {
-        self.kvs.into_pairs().map(Pair::into_value)
-    }
-}
-
-pub struct Subpattern {
-    invoke: String,
-    produce: String,
-}
-
-impl Subpattern {
-    fn new(name: &Ident, lit: &str) -> Self {
-        Subpattern {
-            invoke: format!("(?&{})", name),
-            produce: format!("(?:{})", lit),
+        if let Some((name, _)) = self.map.iter().find(|(name, _)| *name == param) {
+            errors
+                .err(format!("{} can only be assigned once", param), param.span())
+                .err("Previously assigned here", name.span());
+            return;
         }
+
+        // Validate the literal as proper regex. If it's not, error and manufacture a substitute.
+        let lit = match &lit {
+            Literal::Utf8(s) => match Mir::utf8(&s.value()) {
+                Ok(_) => lit,
+                Err(err) => {
+                    errors.err(err, lit.span());
+                    Literal::Utf8(LitStr::new(&param.to_string(), lit.span()))
+                }
+            },
+            Literal::Bytes(b) => {
+                let source = bytes_to_regex_string(b.value());
+                match Mir::binary(&source) {
+                    Ok(_) => lit,
+                    Err(err) => {
+                        errors.err(err, lit.span());
+                        Literal::Bytes(LitByteStr::new(param.to_string().as_bytes(), lit.span()))
+                    }
+                }
+            }
+        };
+
+        self.map.push((param, lit));
     }
 
-    pub fn utf8(name: &Ident, lit: &str) -> Result<Self> {
-        let _ = Mir::utf8(lit)?;
-        Ok(Self::new(name, lit))
-    }
+    pub fn fix(&self, lit: &Literal, errors: &mut Errors) -> String {
+        let mut i = 0;
+        let mut pattern = match lit {
+            Literal::Utf8(s) => s.value(),
+            Literal::Bytes(b) => bytes_to_regex_string(b.value()),
+        };
 
-    pub fn binary(name: &Ident, lit: &str) -> Result<Self> {
-        let _ = Mir::binary(lit)?;
-        Ok(Self::new(name, lit))
-    }
+        while i < pattern.len() {
+            if let Some(f) = pattern[i..].find("(?&") {
+                i += f;
+                pattern.replace_range(i..i + 3, "(?:");
+                i += 3;
+            } else {
+                break; // done!
+            }
 
-    pub fn fix<'a>(&self, pattern: String) -> String {
-        pattern.replace(&self.invoke, &self.produce)
+            let subref_end = if let Some(f) = pattern[i..].find(')') {
+                i + f
+            } else {
+                pattern.truncate(i); // truncate so latter error doesn't suppress
+                break; // regex-syntax will report the unclosed group
+            };
+
+            let name = &pattern[i..subref_end];
+            let name = match syn::parse_str::<Ident>(name) {
+                Ok(name) => name,
+                Err(_) => {
+                    errors.err(
+                        format!("subpattern reference `{}` is not an identifier", name),
+                        lit.span(),
+                    );
+                    // we emitted the error; make something up and continue
+                    pattern.replace_range(i..subref_end, "_");
+                    i += 2;
+                    continue;
+                }
+            };
+
+            match self.map.iter().find(|(def, _)| *def == name) {
+                Some((_, val)) => match val {
+                    Literal::Utf8(val) => {
+                        let subpattern = val.value();
+                        pattern.replace_range(i..subref_end, &subpattern);
+                        i += subpattern.len() + 1;
+                    }
+                    Literal::Bytes(val) => {
+                        let subpattern = bytes_to_regex_string(val.value());
+                        pattern.replace_range(i..subref_end, &subpattern);
+                        i += subpattern.len() + 1;
+                    }
+                },
+                None => {
+                    errors.err(
+                        format!("subpattern reference `{}` has not been defined", name),
+                        lit.span(),
+                    );
+                    // leaving `(?:name)` is fine
+                    i = subref_end + 1;
+                }
+            }
+        }
+
+        pattern
     }
 }

--- a/logos-derive/src/parser/subpattern.rs
+++ b/logos-derive/src/parser/subpattern.rs
@@ -1,0 +1,21 @@
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::{Pair, Punctuated};
+use syn::{MetaNameValue, Token};
+
+pub struct SubpatternInput {
+    kvs: Punctuated<MetaNameValue, Token![,]>,
+}
+
+impl Parse for SubpatternInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(SubpatternInput {
+            kvs: Punctuated::parse_terminated(input)?,
+        })
+    }
+}
+
+impl SubpatternInput {
+    pub fn into_iter(self) -> impl Iterator<Item = MetaNameValue> {
+        self.kvs.into_pairs().map(Pair::into_value)
+    }
+}

--- a/logos-derive/src/parser/subpattern.rs
+++ b/logos-derive/src/parser/subpattern.rs
@@ -1,6 +1,9 @@
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::{Pair, Punctuated};
-use syn::{MetaNameValue, Token};
+use syn::{Ident, LitStr, MetaNameValue, Token};
+
+use crate::error::{Error, Result};
+use crate::mir::Mir;
 
 pub struct SubpatternInput {
     kvs: Punctuated<MetaNameValue, Token![,]>,
@@ -17,5 +20,33 @@ impl Parse for SubpatternInput {
 impl SubpatternInput {
     pub fn into_iter(self) -> impl Iterator<Item = MetaNameValue> {
         self.kvs.into_pairs().map(Pair::into_value)
+    }
+}
+
+pub struct Subpattern {
+    invoke: String,
+    produce: String,
+}
+
+impl Subpattern {
+    fn new(name: &Ident, lit: &str) -> Self {
+        Subpattern {
+            invoke: format!("(?&{})", name),
+            produce: format!("(?:{})", lit),
+        }
+    }
+
+    pub fn utf8(name: &Ident, lit: &str) -> Result<Self> {
+        let _ = Mir::utf8(lit)?;
+        Ok(Self::new(name, lit))
+    }
+
+    pub fn binary(name: &Ident, lit: &str) -> Result<Self> {
+        let _ = Mir::binary(lit)?;
+        Ok(Self::new(name, lit))
+    }
+
+    pub fn fix<'a>(&self, pattern: String) -> String {
+        pattern.replace(&self.invoke, &self.produce)
     }
 }

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -11,7 +11,7 @@ enum Token {
     #[regex(r#""([^"\\]|\\t|\\u|\\n|\\")*""#)]
     LiteralString,
 
-    #[regex("0[xX][0-9a-fA-F]+")]
+    #[regex("0[xX](?&xdigit)+")]
     LiteralHex,
 
     #[regex("-?[0-9]+")]

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -2,7 +2,7 @@ use logos::lookup;
 use logos_derive::Logos;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
-#[logos(subpattern(xdigit = r"[0-9a-fA-F]"))]
+#[logos(subpattern xdigit = r"[0-9a-fA-F]")]
 enum Token {
     #[regex(r"[ \t\n\f]+", logos::skip)]
     #[error]

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -2,6 +2,7 @@ use logos::lookup;
 use logos_derive::Logos;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
+#[logos(subpattern(xdigit = r"[0-9a-fA-F]"))]
 enum Token {
     #[regex(r"[ \t\n\f]+", logos::skip)]
     #[error]


### PR DESCRIPTION
Adds the ability to write `#[logos(subpattern name = r"regex")]` on the token enum, which is then used as a "subroutine" in regex rule definitions with the syntax `(?&name)`. Closes #109.