### PR TITLE
Bugfixes

### DIFF
--- a/logos-derive/src/graph/impls.rs
+++ b/logos-derive/src/graph/impls.rs
@@ -1,6 +1,7 @@
 use std::hash::{Hash, Hasher};
+use std::fmt::{self, Debug, Display};
 
-use crate::graph::{Graph, Rope, Fork, Node, Range};
+use crate::graph::{Graph, Rope, Fork, NodeId, Node, Range};
 
 impl<T> From<Fork> for Node<T> {
     fn from(fork: Fork) -> Self {
@@ -42,6 +43,12 @@ impl<T> Hash for Node<T> {
     }
 }
 
+impl Debug for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
 /// We don't need debug impls in release builds
 // #[cfg(test)]
 mod debug {
@@ -49,7 +56,6 @@ mod debug {
     use crate::graph::rope::Miss;
     use crate::graph::Disambiguate;
     use std::cmp::{Ord, Ordering};
-    use std::fmt::{self, Debug, Display};
 
     impl Disambiguate for &str {
         fn cmp(left: &&str, right: &&str) -> Ordering {

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -6,6 +6,7 @@
 
 // The `quote!` macro requires deep recursion.
 #![recursion_limit = "196"]
+#![doc(html_logo_url = "https://maciej.codes/kosz/logos.png")]
 
 mod error;
 mod generator;

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -290,7 +290,7 @@ pub fn logos(input: TokenStream) -> TokenStream {
         fn _error<'s>(lex: &mut Lexer<'s>) {
             lex.bump_unchecked(1);
 
-            lex.set(#name::#error);
+            lex.error();
         }
 
         #body

--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -163,6 +163,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
+#![doc(html_logo_url = "https://maciej.codes/kosz/logos.png")]
 
 #[cfg(not(feature = "std"))]
 extern crate core as std;

--- a/tests/tests/css.rs
+++ b/tests/tests/css.rs
@@ -12,7 +12,7 @@ enum Token {
     #[regex("cm|mm|Q|in|pc|pt|px")]
     AbsoluteLength,
 
-    #[regex("[+-]?[0-9]*[.]?[0-9]+(?:[eE][+-]?[0-9]+)?")]
+    #[regex("[+-]?[0-9]*[.]?[0-9]+(?:[eE][+-]?[0-9]+)?", priority = 2)]
     Number,
 
     #[regex("[-a-zA-Z_][a-zA-Z0-9_-]*")]

--- a/tests/tests/edgecase.rs
+++ b/tests/tests/edgecase.rs
@@ -493,6 +493,34 @@ mod maybe_in_loop {
     }
 }
 
+mod unicode_error_split {
+    use super::*;
+
+    #[test]
+    fn test() {
+        use logos::Logos;
+
+        #[derive(Logos, Debug, PartialEq)]
+        enum Test {
+            #[token("a")]
+            A,
+
+            #[error]
+            Error,
+        }
+
+        let mut lex = Test::lexer("💩");
+        let _ = lex.next();
+        let bytes = lex.slice().as_bytes();
+        println!("bytes: {:?}", bytes);
+
+        // all lines bellow here throws
+        let s = std::str::from_utf8(bytes).unwrap();
+        assert_eq!(s, "💩");
+        assert_eq!(lex.span(), 0..4);
+    }
+}
+
 mod merging_asymmetric_loops {
     use logos::Logos;
 

--- a/tests/tests/edgecase.rs
+++ b/tests/tests/edgecase.rs
@@ -514,7 +514,6 @@ mod unicode_error_split {
         let bytes = lex.slice().as_bytes();
         println!("bytes: {:?}", bytes);
 
-        // all lines bellow here throws
         let s = std::str::from_utf8(bytes).unwrap();
         assert_eq!(s, "💩");
         assert_eq!(lex.span(), 0..4);

--- a/tests/tests/edgecase.rs
+++ b/tests/tests/edgecase.rs
@@ -493,17 +493,19 @@ mod maybe_in_loop {
     }
 }
 
-// TODO: Fix compilation error on this
+// // TODO: Fix compilation error on this
 // mod loops_in_loops2 {
 //     use logos::Logos;
 
 //     #[derive(Logos)]
 //     pub enum Token2 {
-//         #[regex(r#"[!#$%&*+-./<=>?@\\^|~:]+"#)]
-//         Operator,
+//         #[regex(r#"[ab]+"#)]
+//         #[regex(r"a(a*b|a)*")]
+//         Overlapping,
 
+//         // #[regex(r#"[!#$%&*+-./<=>?@\\^|~:]+"#)]
+//         // #[regex(r"/([^*]*[*]+[^*/])*([^*]*[*]+|[^*])*", logos::skip)]
 //         #[error]
-//         #[regex(r"/\*([^\*]*\*+[^\*/])*([^\*]*\*+|[^\*])*\*/", logos::skip)]
 //         Error,
 //     }
 // }

--- a/tests/tests/edgecase.rs
+++ b/tests/tests/edgecase.rs
@@ -493,19 +493,19 @@ mod maybe_in_loop {
     }
 }
 
-// // TODO: Fix compilation error on this
-// mod loops_in_loops2 {
-//     use logos::Logos;
+mod merging_asymmetric_loops {
+    use logos::Logos;
 
-//     #[derive(Logos)]
-//     pub enum Token2 {
-//         #[regex(r#"[ab]+"#)]
-//         #[regex(r"a(a*b|a)*")]
-//         Overlapping,
+    #[test]
+    fn must_compile() {
+        #[derive(Logos)]
+        pub enum Token2 {
+            #[regex(r#"[!#$%&*+-./<=>?@\\^|~:]+"#)]
+            Operator,
 
-//         // #[regex(r#"[!#$%&*+-./<=>?@\\^|~:]+"#)]
-//         // #[regex(r"/([^*]*[*]+[^*/])*([^*]*[*]+|[^*])*", logos::skip)]
-//         #[error]
-//         Error,
-//     }
-// }
+            #[regex(r"/([^*]*[*]+[^*/])*([^*]*[*]+|[^*])*", logos::skip)]
+            #[error]
+            Error,
+        }
+    }
+}


### PR DESCRIPTION
+ Added a mechanism for node merges to be deferred until a concrete `Node` is inserted into a reserved slot. All deferred merges of `a + b -> c` also flag `a + c -> c` and `b + c -> c` as complete merges. This successfully breaks merging of asymmetric loops in a way that makes me very happy. Fixes #132.
+ Lexing errors on first byte of a token now properly respect char boundaries (fixes #138).