### PR TITLE
WIP - Add a peekable iterator

### DIFF
--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -177,7 +177,7 @@ pub mod source;
 #[doc(hidden)]
 pub mod internal;
 
-pub use crate::lexer::{Lexer, Span, SpannedIter};
+pub use crate::lexer::{Lexer, PeekableIter, Span, SpannedIter};
 pub use crate::source::Source;
 
 /// Trait implemented for an enum representing all tokens. You should never have

--- a/tests/tests/simple.rs
+++ b/tests/tests/simple.rs
@@ -236,6 +236,22 @@ fn spanned_iterator() {
 }
 
 #[test]
+fn peekable_iterator() {
+    let mut iter = Token::lexer("pri priv priva private").peekable();
+
+    assert_eq!(Some(&Token::Identifier), iter.peek());
+    assert_eq!(Some(Token::Identifier), iter.next());
+    assert_eq!(Some(&Token::Priv), iter.peek());
+    assert_eq!(Some(&Token::Priv), iter.peek());
+    assert_eq!(Some(Token::Priv), iter.next());
+    assert_eq!(Some(Token::Identifier), iter.next());
+    assert_eq!(Some(Token::Private), iter.next());
+    assert_eq!(None, iter.peek());
+    assert_eq!(None, iter.next());
+    assert_eq!(None, iter.peek());
+}
+
+#[test]
 fn numbers() {
     assert_lex(
         "0 1 2 3 4 10 42 1337",


### PR DESCRIPTION
Following on from the discussion in #147, this PR adds a `peekable()` method to `Lexer`, which returns a custom `Peekable`-like iterator that has `peek()` as well as accessors for some of `Lexer`'s interface, namely `.extras`, `span()` and `slice()`.