### PR TITLE
Fix a number of Clippy warnings

### DIFF
--- a/logos-derive/src/generator/mod.rs
+++ b/logos-derive/src/generator/mod.rs
@@ -107,7 +107,7 @@ impl<'a> Generator<'a> {
 
         if !self.gotos.contains_key(&key) {
             let meta = &self.meta[id];
-            let enters_loop = meta.loop_entry_from.len() > 0;
+            let enters_loop = !meta.loop_entry_from.is_empty();
 
 
             let bump = if enters_loop || !ctx.can_backtrack() {

--- a/logos-derive/src/graph/range.rs
+++ b/logos-derive/src/graph/range.rs
@@ -43,21 +43,23 @@ impl Iterator for Range {
     type Item = u8;
 
     fn next(&mut self) -> Option<u8> {
-        if self.start < self.end {
-            let res = self.start;
-            self.start += 1;
+        match self.start.cmp(&self.end) {
+            std::cmp::Ordering::Less => {
+                let res = self.start;
+                self.start += 1;
 
-            Some(res)
-        } else if self.start == self.end {
-            let res = self.start;
+                Some(res)
+            }
+            std::cmp::Ordering::Equal => {
+                let res = self.start;
 
-            // Necessary so that range 0xFF-0xFF doesn't loop forever
-            self.start = 0xFF;
-            self.end = 0x00;
+                // Necessary so that range 0xFF-0xFF doesn't loop forever
+                self.start = 0xFF;
+                self.end = 0x00;
 
-            Some(res)
-        } else {
-            None
+                Some(res)
+            }
+            std::cmp::Ordering::Greater => None,
         }
     }
 }
@@ -109,7 +111,7 @@ mod tests {
     #[test]
     fn range_iter_one() {
         let byte = Range::from(b'!');
-        let collected = byte.into_iter().take(1000).collect::<Vec<_>>();
+        let collected = byte.take(1000).collect::<Vec<_>>();
 
         assert_eq!(b"!", &collected[..]);
     }
@@ -117,7 +119,7 @@ mod tests {
     #[test]
     fn range_iter_few() {
         let byte = Range { start: b'a', end: b'd' };
-        let collected = byte.into_iter().take(1000).collect::<Vec<_>>();
+        let collected = byte.take(1000).collect::<Vec<_>>();
 
         assert_eq!(b"abcd", &collected[..]);
     }
@@ -126,7 +128,7 @@ mod tests {
     fn range_iter_bunds() {
         let byte = Range::from(0xFA..=0xFF);
 
-        let collected = byte.into_iter().take(1000).collect::<Vec<_>>();
+        let collected = byte.take(1000).collect::<Vec<_>>();
 
         assert_eq!(b"\xFA\xFB\xFC\xFD\xFE\xFF", &collected[..]);
     }

--- a/logos-derive/src/mir.rs
+++ b/logos-derive/src/mir.rs
@@ -100,7 +100,7 @@ impl TryFrom<Hir> for Mir {
             },
             HirKind::Repetition(repetition) => {
                 if !repetition.greedy {
-                    Err("#[regex]: non-greedy parsing is currently unsupported.")?;
+                    return Err("#[regex]: non-greedy parsing is currently unsupported.".into());
                 }
 
                 let kind = repetition.kind;
@@ -120,7 +120,7 @@ impl TryFrom<Hir> for Mir {
                         ]))
                     },
                     RepetitionKind::Range(..) => {
-                        Err("#[regex]: {n,m} repetition range is currently unsupported.")?
+                        Err("#[regex]: {n,m} repetition range is currently unsupported.".into())
                     },
                 }
             },
@@ -128,10 +128,10 @@ impl TryFrom<Hir> for Mir {
                 Mir::try_from(*group.hir)
             },
             HirKind::WordBoundary(_) => {
-                Err("#[regex]: word boundaries are currently unsupported.")?
+                Err("#[regex]: word boundaries are currently unsupported.".into())
             },
             HirKind::Anchor(_) => {
-                Err("#[regex]: anchors in #[regex] are currently unsupported.")?
+                Err("#[regex]: anchors in #[regex] are currently unsupported.".into())
             },
         }
     }

--- a/logos-derive/src/parser/type_params.rs
+++ b/logos-derive/src/parser/type_params.rs
@@ -121,11 +121,8 @@ pub fn replace_lifetime(ty: &mut Type) {
                 })
                 .flat_map(|ab| ab.args.iter_mut())
                 .for_each(|arg| {
-                    match arg {
-                        GenericArgument::Lifetime(lt) => {
-                            *lt = Lifetime::new("'s", lt.span());
-                        },
-                        _ => (),
+                    if let GenericArgument::Lifetime(lt) = arg {
+                        *lt = Lifetime::new("'s", lt.span());
                     }
                 });
         },

--- a/logos/src/source.rs
+++ b/logos/src/source.rs
@@ -28,15 +28,13 @@ pub trait Source {
     /// ```rust
     /// use logos::Source;
     ///
-    /// fn main() {
-    ///     let foo = "foo";
+    /// let foo = "foo";
     ///
-    ///     assert_eq!(foo.read(0), Some(b"foo"));     // Option<&[u8; 3]>
-    ///     assert_eq!(foo.read(0), Some(b"fo"));      // Option<&[u8; 2]>
-    ///     assert_eq!(foo.read(2), Some(b'o'));       // Option<u8>
-    ///     assert_eq!(foo.read::<&[u8; 4]>(0), None); // Out of bounds
-    ///     assert_eq!(foo.read::<&[u8; 2]>(2), None); // Out of bounds
-    /// }
+    /// assert_eq!(foo.read(0), Some(b"foo"));     // Option<&[u8; 3]>
+    /// assert_eq!(foo.read(0), Some(b"fo"));      // Option<&[u8; 2]>
+    /// assert_eq!(foo.read(2), Some(b'o'));       // Option<u8>
+    /// assert_eq!(foo.read::<&[u8; 4]>(0), None); // Out of bounds
+    /// assert_eq!(foo.read::<&[u8; 2]>(2), None); // Out of bounds
     /// ```
     fn read<'a, Chunk>(&'a self, offset: usize) -> Option<Chunk>
     where
@@ -53,11 +51,8 @@ pub trait Source {
     /// ```rust
     /// use logos::Source;
     ///
-    /// fn main() {
-    ///     let foo = "It was the year when they finally immanentized the Eschaton.";
-    ///
-    ///     assert_eq!(<str as Source>::slice(&foo, 51..59), Some("Eschaton"));
-    /// }
+    /// let foo = "It was the year when they finally immanentized the Eschaton.";
+    /// assert_eq!(<str as Source>::slice(&foo, 51..59), Some("Eschaton"));
     /// ```
     fn slice(&self, range: Range<usize>) -> Option<&Self::Slice>;
 
@@ -69,12 +64,10 @@ pub trait Source {
     /// ```rust
     /// use logos::Source;
     ///
-    /// fn main() {
-    ///     let foo = "It was the year when they finally immanentized the Eschaton.";
+    /// let foo = "It was the year when they finally immanentized the Eschaton.";
     ///
-    ///     unsafe {
-    ///         assert_eq!(<str as Source>::slice_unchecked(&foo, 51..59), "Eschaton");
-    ///     }
+    /// unsafe {
+    ///     assert_eq!(<str as Source>::slice_unchecked(&foo, 51..59), "Eschaton");
     /// }
     /// ```
     unsafe fn slice_unchecked(&self, range: Range<usize>) -> &Self::Slice;


### PR DESCRIPTION
I couldn’t fix all of them, but I did fix thirteen of them. I’d recommend adding Clippy to CI to catch these early on.