### PR TITLE
Use actions-rs/cargo instead of running cargo test manually

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,5 +23,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-      - name: Run tests
-        run: cargo test --verbose
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose


### PR DESCRIPTION
This shows errors from tests using the GitHub UI, rather than just giving you the text of the error.