### PR TITLE
Remove unused lookup! support

### DIFF
--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -24,7 +24,7 @@ use util::MaybeVoid;
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use quote::{quote, ToTokens};
+use quote::quote;
 use syn::spanned::Spanned;
 use syn::{Fields, ItemEnum};
 
@@ -32,7 +32,6 @@ use syn::{Fields, ItemEnum};
 pub fn logos(input: TokenStream) -> TokenStream {
     let mut item: ItemEnum = syn::parse(input).expect("Logos can be only be derived for enums");
 
-    let mut size = item.variants.len();
     let name = &item.ident;
 
     let mut error = None;
@@ -64,16 +63,6 @@ pub fn logos(input: TokenStream) -> TokenStream {
     let mut graph = Graph::new();
 
     for variant in &mut item.variants {
-        if let Some((_, expr)) = variant.discriminant.take() {
-            let expr = expr.into_token_stream();
-            let value = expr.to_string().parse().unwrap_or(usize::max_value());
-
-            if value >= size {
-                // Size must always be 1 greater than highest discriminant value
-                size = value + 1;
-            }
-        }
-
         let field = match &mut variant.fields {
             Fields::Unit => MaybeVoid::Void,
             Fields::Unnamed(fields) => {
@@ -209,8 +198,6 @@ pub fn logos(input: TokenStream) -> TokenStream {
                 type Extras = #extras;
 
                 type Source = #source;
-
-                const SIZE: usize = #size;
 
                 #error_def
 

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -1,4 +1,3 @@
-use logos::lookup;
 use logos_derive::Logos;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
@@ -175,19 +174,6 @@ mod advanced {
                 (Token::Cyrillic, "свидания", 5..21),
             ],
         );
-    }
-
-    #[test]
-    fn lookup() {
-        static LUT: [Option<&'static str>; Token::SIZE] = lookup! {
-            Token::Polish => Some("Polish"),
-            Token::Rustaceans => Some("🦀"),
-            _ => None,
-        };
-
-        assert_eq!(LUT[Token::Polish as usize], Some("Polish"));
-        assert_eq!(LUT[Token::Rustaceans as usize], Some("🦀"));
-        assert_eq!(LUT[Token::Cyrillic as usize], None);
     }
 
     #[test]


### PR DESCRIPTION
This is entirely unused by logos's internals now, and is actually currently not correct in the face of explicit discriminants (as the discriminant of an enum variant can exceed `<Token as Logos>::SIZE`. Additionally, since we have to parse the explicit discriminant in a derive macro, said explicit discriminants are restricted to being literals, not expressions such as `u16::MAX`.

As support for `lookup!` tables is no longer necessary and is buggy and a cause of very inscrutable compiler errors (#192), I suggest that we just remove it, and suggest externals users use a different crate such as [`enum-map`](https://lib.rs/crates/enum-map) for equivalent functionality.

Fixes #192 (by removing the impacted code).