### PR TITLE
Add support for case insensitivity

### DIFF
--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -19,7 +19,7 @@ mod util;
 use generator::Generator;
 use graph::{DisambiguationError, Fork, Graph, Rope};
 use leaf::Leaf;
-use parser::{ApplieIgnoreFlags, Mode, Parser};
+use parser::{Mode, Parser};
 use util::MaybeVoid;
 
 use proc_macro::TokenStream;

--- a/logos-derive/src/mir.rs
+++ b/logos-derive/src/mir.rs
@@ -27,11 +27,31 @@ impl Mir {
         Mir::try_from(ParserBuilder::new().build().parse(source)?)
     }
 
+    pub fn utf8_ignore_case(source: &str) -> Result<Mir> {
+        Mir::try_from(
+            ParserBuilder::new()
+                .case_insensitive(true)
+                .build()
+                .parse(source)?,
+        )
+    }
+
     pub fn binary(source: &str) -> Result<Mir> {
         Mir::try_from(
             ParserBuilder::new()
                 .allow_invalid_utf8(true)
                 .unicode(false)
+                .build()
+                .parse(source)?,
+        )
+    }
+
+    pub fn binary_ignore_case(source: &str) -> Result<Mir> {
+        Mir::try_from(
+            ParserBuilder::new()
+                .allow_invalid_utf8(true)
+                .unicode(false)
+                .case_insensitive(true)
                 .build()
                 .parse(source)?,
         )

--- a/logos-derive/src/parser/definition.rs
+++ b/logos-derive/src/parser/definition.rs
@@ -5,12 +5,13 @@ use crate::error::{Errors, Result};
 use crate::leaf::Callback;
 use crate::mir::Mir;
 use crate::parser::nested::NestedValue;
-use crate::parser::{Parser, Subpatterns};
+use crate::parser::{IgnoreFlags, Parser, Subpatterns};
 
 pub struct Definition {
     pub literal: Literal,
     pub priority: Option<usize>,
     pub callback: Option<Callback>,
+    pub ignore_flags: IgnoreFlags,
 }
 
 pub enum Literal {
@@ -24,6 +25,7 @@ impl Definition {
             literal,
             priority: None,
             callback: None,
+            ignore_flags: IgnoreFlags::Empty,
         }
     }
 
@@ -66,6 +68,12 @@ impl Definition {
             }
             ("callback", _) => {
                 parser.err("Expected: callback = ...", name.span());
+            }
+            ("ignore", NestedValue::Group(tokens)) => {
+                self.ignore_flags.parse_group(name, tokens, parser);
+            }
+            ("ignore", _) => {
+                parser.err("Expected: ignore(<flag>, ...)", name.span());
             }
             (unknown, _) => {
                 parser.err(

--- a/logos-derive/src/parser/ignore_flags.rs
+++ b/logos-derive/src/parser/ignore_flags.rs
@@ -1,0 +1,199 @@
+use std::cmp;
+use std::ops::{BitAnd, BitOr};
+
+use proc_macro2::{Ident, TokenStream, TokenTree};
+use regex_syntax::hir;
+
+use crate::mir::Mir;
+use crate::parser::{Literal, Parser};
+use crate::util::is_punct;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct IgnoreFlags {
+    bits: u8,
+}
+
+#[allow(non_upper_case_globals)]
+impl IgnoreFlags {
+    pub const Empty: Self = Self::new(0x00);
+    pub const IgnoreCase: Self = Self::new(0x01);
+    pub const IgnoreAsciiCase: Self = Self::new(0x02);
+
+    #[inline]
+    pub const fn new(bits: u8) -> Self {
+        Self { bits }
+    }
+
+    /// Enables a variant.
+    #[inline]
+    pub fn enable(&mut self, variant: Self) {
+        self.bits |= variant.bits;
+    }
+
+    /// Checks if this `IgnoreFlags` contains *any* of the given variants.
+    #[inline]
+    pub fn contains(&self, variants: Self) -> bool {
+        self.bits & variants.bits != 0
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.bits == 0
+    }
+
+    /// Parses an identifier an enables it for `self`.
+    ///
+    /// Valid inputs are (that produces `true`):
+    /// * `"case"` (incompatible with `"ascii_case"`)
+    /// * `"ascii_case"` (incompatible with `"case"`)
+    ///
+    /// An error causes this function to return `false` and emits an error to
+    /// the given `Parser`.
+    fn parse_ident(&mut self, ident: Ident, parser: &mut Parser) -> bool {
+        match ident.to_string().as_str() {
+            "case" => {
+                if self.contains(Self::IgnoreAsciiCase) {
+                    parser.err(
+                        "\
+                        The flag \"case\" cannot be used along with \"ascii_case\"\
+                        ",
+                        ident.span(),
+                    );
+                    false
+                } else {
+                    self.enable(Self::IgnoreCase);
+                    true
+                }
+            }
+            "ascii_case" => {
+                if self.contains(Self::IgnoreCase) {
+                    parser.err(
+                        "\
+                        The flag \"ascii_case\" cannot be used along with \"case\"\
+                        ",
+                        ident.span(),
+                    );
+                    false
+                } else {
+                    self.enable(Self::IgnoreAsciiCase);
+                    true
+                }
+            }
+            unknown => {
+                parser.err(
+                    format!(
+                        "\
+                        Unknown flag: {}\n\n\
+                        
+                        Expected one of: case, ascii_case\
+                        ",
+                        unknown
+                    ),
+                    ident.span(),
+                );
+                false
+            }
+        }
+    }
+
+    pub fn parse_group(&mut self, name: Ident, tokens: TokenStream, parser: &mut Parser) {
+        // Little finite state machine to parse "<flag>(,<flag>)*,?"
+
+        // FSM description for future maintenance
+        // 0: Initial state
+        //   <flag> -> 1
+        //        _ -> error
+        // 1: A flag was found
+        //        , -> 2
+        //     None -> done
+        //        _ -> error
+        // 2: A comma was found (after a <flag>)
+        //   <flag> -> 1
+        //     None -> done
+        //        _ -> error
+        let mut state = 0u8;
+
+        let mut tokens = tokens.into_iter();
+
+        loop {
+            state = match state {
+                0 => match tokens.next() {
+                    Some(TokenTree::Ident(ident)) => {
+                        if self.parse_ident(ident, parser) {
+                            1
+                        } else {
+                            return;
+                        }
+                    }
+                    _ => {
+                        parser.err(
+                            "\
+                            Invalid ignore flag\n\n\
+                                
+                            Expected one of: case, ascii_case\
+                            ",
+                            name.span(),
+                        );
+                        return;
+                    }
+                },
+                1 => match tokens.next() {
+                    Some(tt) if is_punct(&tt, ',') => 2,
+                    None => return,
+                    Some(unexpected_tt) => {
+                        parser.err(
+                            format!(
+                                "\
+                                Unexpected token: {:?}\
+                                ",
+                                unexpected_tt.to_string(),
+                            ),
+                            unexpected_tt.span(),
+                        );
+                        return;
+                    }
+                },
+                2 => match tokens.next() {
+                    Some(TokenTree::Ident(ident)) => {
+                        if self.parse_ident(ident, parser) {
+                            1
+                        } else {
+                            return;
+                        }
+                    }
+                    None => return,
+                    Some(unexpected_tt) => {
+                        parser.err(
+                            format!(
+                                "\
+                                Unexpected token: {:?}\
+                                ",
+                                unexpected_tt.to_string(),
+                            ),
+                            unexpected_tt.span(),
+                        );
+                        return;
+                    }
+                },
+                _ => unreachable!("Internal Error: invalid state ({})", state),
+            }
+        }
+    }
+}
+
+impl BitOr for IgnoreFlags {
+    type Output = Self;
+
+    fn bitor(self, other: Self) -> Self {
+        Self::new(self.bits | other.bits)
+    }
+}
+
+impl BitAnd for IgnoreFlags {
+    type Output = Self;
+
+    fn bitand(self, other: Self) -> Self {
+        Self::new(self.bits & other.bits)
+    }
+}
+

--- a/logos-derive/src/parser/mod.rs
+++ b/logos-derive/src/parser/mod.rs
@@ -15,7 +15,7 @@ mod subpattern;
 mod type_params;
 
 pub use self::definition::{Definition, Literal};
-pub use self::ignore_flags::{ApplieIgnoreFlags, IgnoreFlags};
+pub use self::ignore_flags::IgnoreFlags;
 use self::nested::{AttributeParser, Nested, NestedValue};
 pub use self::subpattern::Subpatterns;
 use self::type_params::{replace_lifetime, traverse_type, TypeParams};

--- a/logos-derive/src/parser/mod.rs
+++ b/logos-derive/src/parser/mod.rs
@@ -9,11 +9,13 @@ use crate::leaf::{Callback, InlineCallback};
 use crate::util::{expect_punct, MaybeVoid};
 
 mod definition;
+mod ignore_flags;
 mod nested;
 mod subpattern;
 mod type_params;
 
 pub use self::definition::{Definition, Literal};
+pub use self::ignore_flags::{ApplieIgnoreFlags, IgnoreFlags};
 use self::nested::{AttributeParser, Nested, NestedValue};
 pub use self::subpattern::Subpatterns;
 use self::type_params::{replace_lifetime, traverse_type, TypeParams};

--- a/tests/tests/ignore_case.rs
+++ b/tests/tests/ignore_case.rs
@@ -166,6 +166,9 @@ mod ignore_case {
         Eleve,
         #[token("à", ignore(case))]
         A,
+
+        #[token("[abc]+", ignore(case))]
+        Abc,
     }
 
     #[test]
@@ -179,6 +182,22 @@ mod ignore_case {
                 (Words::A, "à", 30..32),
                 (Words::A, "À", 33..35),
                 (Words::Error, "a", 36..37),
+            ],
+        )
+    }
+
+    #[test]
+    fn tokens_regex_escaped() {
+        assert_lex(
+            "[abc]+ abccBA",
+            &[
+                (Words::Abc, "[abc]+", 0..6),
+                (Words::Error, "a", 7..8),
+                (Words::Error, "b", 8..9),
+                (Words::Error, "c", 9..10),
+                (Words::Error, "c", 10..11),
+                (Words::Error, "B", 11..12),
+                (Words::Error, "A", 12..13),
             ],
         )
     }

--- a/tests/tests/ignore_case.rs
+++ b/tests/tests/ignore_case.rs
@@ -1,0 +1,213 @@
+mod ignore_ascii_case {
+    use logos::Logos;
+    use tests::assert_lex;
+
+    #[derive(Logos, Debug, PartialEq, Eq)]
+    enum Words {
+        #[error]
+        #[regex(" +", logos::skip)]
+        Error,
+
+        #[token("lOwERCaSe", ignore(ascii_case))]
+        Lowercase,
+        #[token("or", ignore(ascii_case))]
+        Or,
+        #[token("UppeRcaSE", ignore(ascii_case))]
+        Uppercase,
+        #[token(":", ignore(ascii_case))]
+        Colon,
+        #[token("ThAT", ignore(ascii_case))]
+        That,
+        #[token("IS", ignore(ascii_case))]
+        Is,
+        #[token("the", ignore(ascii_case))]
+        The,
+        #[token("QuEsTiOn", ignore(ascii_case))]
+        Question,
+
+        #[token("MON", ignore(ascii_case))]
+        Mon,
+        #[token("frèRE", ignore(ascii_case))]
+        Frere,
+        #[token("ÉTAIT", ignore(ascii_case))]
+        Etait,
+        #[token("là", ignore(ascii_case))]
+        La,
+        #[token("cET", ignore(ascii_case))]
+        Cet,
+        #[token("éTé", ignore(ascii_case))]
+        Ete,
+    }
+
+    #[test]
+    fn tokens_simple() {
+        assert_lex(
+            "LowErcase or UppeRCase: ThAT iS tHe question",
+            &[
+                (Words::Lowercase, "LowErcase", 0..9),
+                (Words::Or, "or", 10..12),
+                (Words::Uppercase, "UppeRCase", 13..22),
+                (Words::Colon, ":", 22..23),
+                (Words::That, "ThAT", 24..28),
+                (Words::Is, "iS", 29..31),
+                (Words::The, "tHe", 32..35),
+                (Words::Question, "question", 36..44),
+            ],
+        )
+    }
+
+    #[test]
+    fn tokens_nonascii() {
+        assert_lex(
+            "Mon Frère Était lÀ cet Été",
+            &[
+                (Words::Mon, "Mon", 0..3),
+                (Words::Frere, "Frère", 4..10),
+                (Words::Etait, "Était", 11..17),
+                (Words::Error, "l", 18..19),
+                (Words::Error, "À", 19..21),
+                (Words::Cet, "cet", 22..25),
+                (Words::Error, "É", 26..28),
+                (Words::Error, "t", 28..29),
+                (Words::Error, "é", 29..31),
+            ],
+        )
+    }
+
+    #[derive(Logos, Debug, PartialEq, Eq)]
+    enum Letters {
+        #[error]
+        #[regex(" +", logos::skip)]
+        Error,
+
+        #[regex("a", ignore(ascii_case))]
+        Single,
+        #[regex("bc", ignore(ascii_case))]
+        Concat,
+        #[regex("[de]", ignore(ascii_case))]
+        Altern,
+        #[regex("f+", ignore(ascii_case))]
+        Loop,
+        #[regex("gg?", ignore(ascii_case))]
+        Maybe,
+        #[regex("[h-k]+", ignore(ascii_case))]
+        Range,
+
+        #[regex("à", ignore(ascii_case))]
+        NaSingle,
+        #[regex("éèd", ignore(ascii_case))]
+        NaConcat,
+        #[regex("[cûü]+", ignore(ascii_case))]
+        NaAltern,
+        #[regex("i§?", ignore(ascii_case))]
+        NaMaybe,
+        #[regex("[x-à]+", ignore(ascii_case))]
+        NaRange,
+    }
+
+    #[test]
+    fn regex_simple() {
+        assert_lex(
+            "aA BCbC DdEE fFff g gg hHiIjJkK",
+            &[
+                (Letters::Single, "a", 0..1),
+                (Letters::Single, "A", 1..2),
+                (Letters::Concat, "BC", 3..5),
+                (Letters::Concat, "bC", 5..7),
+                (Letters::Altern, "D", 8..9),
+                (Letters::Altern, "d", 9..10),
+                (Letters::Altern, "E", 10..11),
+                (Letters::Altern, "E", 11..12),
+                (Letters::Loop, "fFff", 13..17),
+                (Letters::Maybe, "g", 18..19),
+                (Letters::Maybe, "gg", 20..22),
+                (Letters::Range, "hHiIjJkK", 23..31),
+            ],
+        )
+    }
+
+    #[test]
+    fn regex_nonascii() {
+        assert_lex(
+            "à À éèD Éèd CcûÛüÜC i i§ xXyYzZ|{}",
+            &[
+                (Letters::NaSingle, "à", 0..2),
+                (Letters::NaRange, "À", 3..5),
+                (Letters::NaConcat, "éèD", 6..11),
+                (Letters::NaRange, "É", 12..14),
+                (Letters::Error, "è", 14..16),
+                (Letters::Altern, "d", 16..17),
+                (Letters::NaAltern, "Ccû", 18..22),
+                (Letters::NaRange, "Û", 22..24),
+                (Letters::NaAltern, "ü", 24..26),
+                (Letters::NaRange, "Ü", 26..28),
+                (Letters::NaAltern, "C", 28..29),
+                (Letters::NaMaybe, "i", 30..31),
+                (Letters::NaMaybe, "i§", 32..35),
+                (Letters::NaRange, "xXyYzZ|{}", 36..45),
+            ],
+        )
+    }
+}
+
+mod ignore_case {
+    use logos::Logos;
+    use tests::assert_lex;
+
+    #[derive(Logos, Debug, PartialEq, Eq)]
+    enum Words {
+        #[error]
+        #[regex(" +", logos::skip)]
+        Error,
+
+        #[token("élÉphAnt", ignore(case))]
+        Elephant,
+        #[token("ÉlèvE", ignore(case))]
+        Eleve,
+        #[token("à", ignore(case))]
+        A,
+    }
+
+    #[test]
+    fn tokens() {
+        assert_lex(
+            "ÉLÉPHANT Éléphant ÉLèVE à À a",
+            &[
+                (Words::Elephant, "ÉLÉPHANT", 0..10),
+                (Words::Elephant, "Éléphant", 11..21),
+                (Words::Eleve, "ÉLèVE", 22..29),
+                (Words::A, "à", 30..32),
+                (Words::A, "À", 33..35),
+                (Words::Error, "a", 36..37),
+            ],
+        )
+    }
+
+    #[derive(Logos, PartialEq, Eq, Debug)]
+    enum Sink {
+        #[error]
+        #[regex(" +", logos::skip)]
+        Error,
+
+        #[regex("[abcéà]+", ignore(case))]
+        Letters,
+        #[regex("[0-9]+", ignore(case))]
+        Numbers,
+        #[regex("ééààé", ignore(case))]
+        Sequence,
+    }
+
+    #[test]
+    fn regex() {
+        assert_lex(
+            "aabbccééààéé 00123 ééààé ABCÉÀÀ ÉÉàÀÉ",
+            &[
+                (Sink::Letters, "aabbccééààéé", 0..18),
+                (Sink::Numbers, "00123", 19..24),
+                (Sink::Sequence, "ééààé", 25..35),
+                (Sink::Letters, "ABCÉÀÀ", 36..45),
+                (Sink::Sequence, "ÉÉàÀÉ", 46..56),
+            ],
+        )
+    }
+}


### PR DESCRIPTION
Issue: #196 

Case insensitivity is opt-in using the `ignore(...)` attribute.

```rust
#[derive(Logos)]
struct Token {
    /* ... */
    #[token("été", ignore(case))]
    Ete,
    #[token("DRôLE", ignore(ascii_case))]
    Drole,
    #[regex("[abc]+", ignore(case))]
    Abc,
}

let mut lex = Token::lex("été ÉTÉ DrÔle Drôle AaabbCC");
assert_eq!((Some(Token::Ete), "été"), (lex.next(), lex.slice()));
assert_eq!((Some(Token::Ete), "ÉTÉ"), (lex.next(), lex.slice()));
// Then a bunch of errors because Ô is not an ascii-uppercase ô.
assert_eq!((Some(Token::Drole), "Drôle"),  (lex.next(), lex.slice()));
assert_eq!((Some(Token::Abc), "AaabbCC"),  (lex.next(), lex.slice()));
assert_eq!(None, lex.next());
```

For now, I prevented the user to use both `ascii_case` and `case` at the same time. This can be easily changed.

--------------------------------------------

Internally, all this attribute does is converting the original literal (for tokens) or the MIR (for regular expression) into another MIR that accepts both uppercase and lowercase variants of the input.

```rust
// For example, this ...
#[token("hello", ignore(ascii_case))
Hello,

// ... is treated internally exactly like this
#[regex("[Hh][Ee][Ll][Oo]")]
Hello,
```

# Unanswered questions

* I created the `IgnoreFlags` struct to make the `ignore` attribute more easily expandable. It uses a basic bit field. I wasn't sure whether a new dependency was ok so I implemented myself what the [`bitflags`](https://crates.io/crates/bitflags) crate do (in much much simpler). Do we want a new dependency to make the code cleaner or the little features I implemented are enough?
* I am using MIR to handle case insensitivity. Is this ok or would directly creating forks be faster? If this is not acceptable/maintenable, I think it is possible to adapt the the whole thing trait to make it work. I might need a little help for that though; I found the `generator` module quite complicated to dig into and understand.
* ~Ranges (eg. `regex("[a-z]", ...)`) are currently using [`ClassUnicode::case_fold_simple`](https://docs.rs/regex-syntax/0.6.22/regex_syntax/hir/struct.ClassUnicode.html#method.case_fold_simple)  and normal literals (eg. `regex("abc", ...)`) are using Rust's [`to_lowercase`](https://doc.rust-lang.org/std/primitive.char.html#method.to_lowercase) and [`to_uppercase`](https://doc.rust-lang.org/std/primitive.char.html#method.to_uppercase) functions. This might lead to inconsistencies if those two methods do not convert characters the same way.~ Now everything uses simple folding.
 
PS: This is my first PR ever. If I've done anything wrong, please tell me! I'm both doing this because I needed this feature and to get reviews of my code. Feel free to say it needs some (or a lot) rework :)