### PR TITLE
remove utf8-ranges dependency

### DIFF
--- a/logos-derive/Cargo.toml
+++ b/logos-derive/Cargo.toml
@@ -22,7 +22,6 @@ syn = { version = "1.0.17", features = ["full"] }
 quote = "1.0.3"
 proc-macro2 = "1.0.9"
 regex-syntax = "0.6"
-utf8-ranges = "1.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/logos-derive/src/graph/range.rs
+++ b/logos-derive/src/graph/range.rs
@@ -1,6 +1,6 @@
 use regex_syntax::hir::ClassBytesRange;
 use regex_syntax::hir::ClassUnicodeRange;
-use utf8_ranges::Utf8Range;
+use regex_syntax::utf8::Utf8Range;
 
 use std::cmp::{Ord, Ordering};
 

--- a/logos-derive/src/graph/regex.rs
+++ b/logos-derive/src/graph/regex.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use utf8_ranges::Utf8Sequences;
+use regex_syntax::utf8::Utf8Sequences;
 
 use crate::graph::{Disambiguate, Fork, Graph, Node, NodeId, Range, ReservedId, Rope};
 use crate::mir::{Class, ClassUnicode, Literal, Mir};

--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -333,11 +333,11 @@ pub fn skip<'source, Token: Logos<'source>>(_: &mut Lexer<'source, Token>) -> Sk
 #[cfg(doctest)]
 mod test_readme {
     macro_rules! external_doc_test {
-    ($x:expr) => {
-        #[doc = $x]
-        extern {}
-    };
-  }
+        ($x:expr) => {
+            #[doc = $x]
+            extern "C" {}
+        };
+    }
 
     external_doc_test!(include_str!("../../README.md"));
 }


### PR DESCRIPTION
This removes the `utf8-ranges` dependency as this crate has been [deprecated](https://github.com/BurntSushi/utf8-ranges#readme) and now makes part of the `regex_syntax` crate.