### PR TITLE
Cargo test: Fix warnings for unescaped newlines in multiline strings

### DIFF
--- a/logos-derive/src/graph/mod.rs
+++ b/logos-derive/src/graph/mod.rs
@@ -265,7 +265,7 @@ impl<Leaf> Graph<Leaf> {
             (None, None) => {
                 panic!(
                     "Merging two reserved nodes! This is a bug, please report it:\
-
+                    \
                     https://github.com/maciejhirsz/logos/issues"
                 );
             }
@@ -454,7 +454,7 @@ impl<Leaf> Index<NodeId> for Graph<Leaf> {
     fn index(&self, id: NodeId) -> &Node<Leaf> {
         self.get(id).expect(
             "Indexing into an empty node. This is a bug, please report it at:\n\n\
-
+            \
             https://github.com/maciejhirsz/logos/issues",
         )
     }

--- a/logos-derive/src/lib.rs
+++ b/logos-derive/src/lib.rs
@@ -47,9 +47,8 @@ pub fn logos(input: TokenStream) -> TokenStream {
         // TODO: Remove in future versions
         if attr.path.is_ident("extras") {
             parser.err(
-                "\
-                #[extras] attribute is deprecated. Use #[logos(extras = Type)] instead.\n\n\
-
+                "#[extras] attribute is deprecated. Use #[logos(extras = Type)] instead.\n\n
+                \
                 For help with migration see release notes: \
                 https://github.com/maciejhirsz/logos/releases\
                 ",
@@ -116,7 +115,7 @@ pub fn logos(input: TokenStream) -> TokenStream {
                     parser.err(
                         "\
                         Since 0.11 Logos no longer requires the #[end] variant.\n\n\
-
+                        \
                         For help with migration see release notes: \
                         https://github.com/maciejhirsz/logos/releases\
                         ",
@@ -259,7 +258,7 @@ pub fn logos(input: TokenStream) -> TokenStream {
                 format!(
                     "\
                     A definition of variant `{0}` can match the same input as another definition of variant `{1}`.\n\n\
-
+                    \
                     hint: Consider giving one definition a higher priority: \
                     #[regex(..., priority = {2})]\
                     ",

--- a/logos-derive/src/parser/definition.rs
+++ b/logos-derive/src/parser/definition.rs
@@ -82,7 +82,7 @@ impl Definition {
                     format!(
                         "\
                         Unknown nested attribute: {}\n\n\
-
+                        \
                         Expected one of: priority, callback\
                         ",
                         unknown

--- a/logos-derive/src/parser/ignore_flags.rs
+++ b/logos-derive/src/parser/ignore_flags.rs
@@ -81,7 +81,7 @@ impl IgnoreFlags {
                     format!(
                         "\
                         Unknown flag: {}\n\n\
-                        
+                        \
                         Expected one of: case, ascii_case\
                         ",
                         unknown
@@ -126,7 +126,7 @@ impl IgnoreFlags {
                         parser.err(
                             "\
                             Invalid ignore flag\n\n\
-                                
+                            \
                             Expected one of: case, ascii_case\
                             ",
                             name.span(),

--- a/logos-derive/src/parser/mod.rs
+++ b/logos-derive/src/parser/mod.rs
@@ -115,7 +115,7 @@ impl Parser {
                     self.err(
                         "\
                         trivia are no longer supported.\n\n\
-
+                        \
                         For help with migration see release notes: \
                         https://github.com/maciejhirsz/logos/releases\
                         ",
@@ -179,7 +179,7 @@ impl Parser {
                         self.err(
                             "\
                             Expected a named argument at this position\n\n\
-
+                            \
                             hint: If you are trying to define a callback here use: callback = ...\
                             ",
                             tokens.span(),

--- a/logos-derive/src/parser/type_params.rs
+++ b/logos-derive/src/parser/type_params.rs
@@ -86,7 +86,7 @@ impl TypeParams {
                     errors.err(
                         format!(
                             "Generic type parameter without a concrete type\n\n\
-
+                            \
                             Define a concrete type Logos can use: #[logos(type {} = Type)]",
                             ty,
                         ),


### PR DESCRIPTION
When I ran `cargo test` I got a whole bunch of warnings for unescaped newlines
in multiline error message strings. This PR fixes those warnings by properly escaping newlines.