### PR TITLE
Allow `#[token("x", skip)]` on dataful variants

### DIFF
--- a/logos/src/internal.rs
+++ b/logos/src/internal.rs
@@ -95,7 +95,7 @@ impl<'s, P, E, T: Logos<'s>> CallbackResult<'s, P, T> for Result<P, E> {
     }
 }
 
-impl<'s, T: Logos<'s>> CallbackResult<'s, (), T> for Skip {
+impl<'s, T: Logos<'s>, U> CallbackResult<'s, U, T> for Skip {
     #[inline]
     fn construct<Constructor>(self, _: Constructor, lex: &mut Lexer<'s, T>)
     where


### PR DESCRIPTION
I ended up with a `#[regex("...", logos::skip)]` on a variant `Constant(String)` while reordering, and saw a ``the trait bound `logos::Skip: CallbackResult<'_, String, lexer::Token>` is not satisfied`` error. This attempts to make this case just work.

(In this case I'm attempting to keep commands in rough source order from a ocamllex file I'm porting, thus having an ignore attached to a dataful variant instead of `#[error]` as is usual for Logos.)