### PR TITLE
Add logos(crate = "...") attribute

### DIFF
--- a/logos/Cargo.toml
+++ b/logos/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 edition = "2018"
 
 [dependencies]
-logos-derive = { version = "0.12.1", optional = true }
+logos-derive = { path = "../logos-derive", version = "0.12.1", optional = true }
 
 [features]
 default = ["export_derive", "std"]

--- a/tests/tests/crate_.rs
+++ b/tests/tests/crate_.rs
@@ -1,0 +1,36 @@
+use logos_derive::Logos;
+use tests::assert_lex;
+
+mod some {
+    pub mod path {
+        pub use logos as _logos;
+    }
+}
+
+#[derive(Logos, Debug, Clone, Copy, PartialEq)]
+#[logos(crate = "some::path::_logos")]
+enum Token {
+    #[regex(r"[ \t\n\f]+", logos::skip)]
+    #[error]
+    Error,
+
+    #[regex("-?[0-9]+")]
+    LiteralInteger,
+
+    #[token("'")]
+    SingleQuote,
+}
+
+#[test]
+fn simple() {
+    assert_lex(
+        "' -1'2  '",
+        &[
+            (Token::SingleQuote, "'", 0..1),
+            (Token::LiteralInteger, "-1", 2..4),
+            (Token::SingleQuote, "'", 4..5),
+            (Token::LiteralInteger, "2", 5..6),
+            (Token::SingleQuote, "'", 8..9),
+        ],
+    );
+}


### PR DESCRIPTION
Add a `crate` attribute similiar to what [serde](https://serde.rs/container-attrs.html#crate) has.

This allows logos proc-macro to be used and re-exported from another proc-macro without requiring the user to have logos in scope.