### PR TITLE
Added support for `#[logos(skip "...")]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To achieve those, **Logos**:
  use logos::Logos;
 
  #[derive(Logos, Debug, PartialEq)]
+ #[logos(skip r"[ \t\n\f]+")] // Ignore this regex pattern between tokens
  enum Token {
      // Tokens can be literal strings, of any length.
      #[token("fast")]
@@ -39,12 +40,6 @@ To achieve those, **Logos**:
      // Or regular expressions.
      #[regex("[a-zA-Z]+")]
      Text,
-
-     // Logos requires one token variant to define whitespace,
-     // or any other matches we wish to skip.
-     // It can be named anything you wish.
-     #[regex(r"[ \t\n\f]+", logos::skip)]
-     Ignored,
  }
 
  fn main() {
@@ -96,10 +91,8 @@ which can be used to put data into a variant:
  }
 
  #[derive(Logos, Debug, PartialEq)]
+ #[logos(skip r"[ \t\n\f]+")]
  enum Token {
-     #[regex(r"[ \t\n\f]+", logos::skip)]
-     Ignored,
-
      // Callbacks can use closure syntax, or refer
      // to a function defined elsewhere.
      //

--- a/logos-codegen/src/generator/leaf.rs
+++ b/logos-codegen/src/generator/leaf.rs
@@ -39,6 +39,14 @@ impl<'a> Generator<'a> {
                     callback(lex).construct(#constructor, lex);
                 }
             }
+            Some(Callback::Skip(_)) => {
+                quote! {
+                    #bump
+
+                    lex.trivia();
+                    #name::lex(lex);
+                }
+            }
             None if matches!(leaf.field, MaybeVoid::Void) => quote! {
                 #bump
                 lex.set(Ok(#name::#ident));

--- a/logos-codegen/src/leaf.rs
+++ b/logos-codegen/src/leaf.rs
@@ -1,5 +1,5 @@
 use std::cmp::{Ord, Ordering};
-use std::fmt::{self, Debug};
+use std::fmt::{self, Debug, Display};
 
 use proc_macro2::{Span, TokenStream};
 use syn::{spanned::Spanned, Ident};
@@ -9,7 +9,7 @@ use crate::util::MaybeVoid;
 
 #[derive(Clone)]
 pub struct Leaf<'t> {
-    pub ident: &'t Ident,
+    pub ident: Option<&'t Ident>,
     pub span: Span,
     pub priority: usize,
     pub field: MaybeVoid,
@@ -20,6 +20,7 @@ pub struct Leaf<'t> {
 pub enum Callback {
     Label(TokenStream),
     Inline(Box<InlineCallback>),
+    Skip(Span),
 }
 
 #[derive(Clone)]
@@ -40,6 +41,7 @@ impl Callback {
         match self {
             Callback::Label(tokens) => tokens.span(),
             Callback::Inline(inline) => inline.span,
+            Callback::Skip(span) => *span,
         }
     }
 }
@@ -47,11 +49,21 @@ impl Callback {
 impl<'t> Leaf<'t> {
     pub fn new(ident: &'t Ident, span: Span) -> Self {
         Leaf {
-            ident,
+            ident: Some(ident),
             span,
             priority: 0,
             field: MaybeVoid::Void,
             callback: None,
+        }
+    }
+
+    pub fn new_skip(span: Span) -> Self {
+        Leaf {
+            ident: None,
+            span,
+            priority: 0,
+            field: MaybeVoid::Void,
+            callback: Some(Callback::Skip(span)),
         }
     }
 
@@ -85,12 +97,22 @@ impl<'t> From<Leaf<'t>> for Node<Leaf<'t>> {
 
 impl Debug for Leaf<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "::{}", self.ident)?;
+        write!(f, "::{}", self)?;
 
         match self.callback {
             Some(Callback::Label(ref label)) => write!(f, " ({})", label),
             Some(Callback::Inline(_)) => f.write_str(" (<inline>)"),
+            Some(Callback::Skip(_)) => f.write_str(" (<skip>)"),
             None => Ok(()),
+        }
+    }
+}
+
+impl Display for Leaf<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.ident {
+            Some(ident) => Display::fmt(ident, f),
+            None => f.write_str("<skip>"),
         }
     }
 }

--- a/logos-codegen/src/parser/mod.rs
+++ b/logos-codegen/src/parser/mod.rs
@@ -150,11 +150,8 @@ impl Parser {
                 }
                 ("crate", NestedValue::Assign(value)) => match syn::parse2(value) {
                     Ok(logos_path) => self.logos_path = Some(logos_path),
-                    Err(_) => {
-                        self.err(
-                            r#"Expected: #[logos(crate = some::path::to::logos)]"#,
-                            name.span(),
-                        );
+                    Err(err) => {
+                        self.err(err.to_string(), err.span());
                     }
                 },
                 ("crate", _) => {

--- a/logos-codegen/src/parser/nested.rs
+++ b/logos-codegen/src/parser/nested.rs
@@ -1,5 +1,5 @@
 use proc_macro2::token_stream::IntoIter as TokenIter;
-use proc_macro2::{Ident, TokenStream, TokenTree};
+use proc_macro2::{Ident, Literal, TokenStream, TokenTree};
 use quote::quote;
 
 use crate::util::{expect_punct, is_punct};
@@ -7,6 +7,8 @@ use crate::util::{expect_punct, is_punct};
 pub enum NestedValue {
     /// `name = ...`
     Assign(TokenStream),
+    /// `name "literal"`
+    Literal(Literal),
     /// `name(...)`
     Group(TokenStream),
     /// `name ident = ...`
@@ -88,6 +90,10 @@ impl AttributeParser {
         Nested::Named(name, NestedValue::Assign(value))
     }
 
+    fn parse_literal(&mut self, name: Ident, lit: Literal) -> Nested {
+        Nested::Named(name, NestedValue::Literal(lit))
+    }
+
     fn parse_group(&mut self, name: Ident, group: TokenStream) -> Nested {
         Nested::Named(name, NestedValue::Group(group))
     }
@@ -127,6 +133,7 @@ impl Iterator for AttributeParser {
 
         match self.next_tt() {
             Some(tt) if is_punct(&tt, '=') => Some(self.parse_assign(name)),
+            Some(TokenTree::Literal(lit)) => Some(self.parse_literal(name, lit)),
             Some(TokenTree::Group(group)) => Some(self.parse_group(name, group.stream())),
             Some(TokenTree::Ident(next)) => Some(self.parse_keyword(name, next)),
             Some(next) => Some(self.parse_unnamed(name, next)),

--- a/logos-codegen/src/parser/nested.rs
+++ b/logos-codegen/src/parser/nested.rs
@@ -91,6 +91,9 @@ impl AttributeParser {
     }
 
     fn parse_literal(&mut self, name: Ident, lit: Literal) -> Nested {
+        // TODO: Error if there are any tokens following
+        let _ = self.collect_tail(Empty);
+
         Nested::Named(name, NestedValue::Literal(lit))
     }
 

--- a/logos/src/lib.rs
+++ b/logos/src/lib.rs
@@ -23,6 +23,7 @@
 //! use logos::Logos;
 //!
 //! #[derive(Logos, Debug, PartialEq)]
+//! #[logos(skip r"[ \t\n\f]+")] // Ignore this regex pattern between tokens
 //! enum Token {
 //!     // Tokens can be literal strings, of any length.
 //!     #[token("fast")]
@@ -34,12 +35,6 @@
 //!     // Or regular expressions.
 //!     #[regex("[a-zA-Z]+")]
 //!     Text,
-//!
-//!     // Logos requires one token variant to define whitespace,
-//!     // or any other matches we wish to skip.
-//!     // It can be named anything you wish.
-//!     #[regex(r"[ \t\n\f]+", logos::skip)]
-//!     Ignored,
 //! }
 //!
 //! fn main() {
@@ -91,10 +86,8 @@
 //! }
 //!
 //! #[derive(Logos, Debug, PartialEq)]
+//! #[logos(skip r"[ \t\n\f]+")]
 //! enum Token {
-//!     #[regex(r"[ \t\n\f]+", logos::skip)]
-//!     Ignored,
-//!
 //!     // Callbacks can use closure syntax, or refer
 //!     // to a function defined elsewhere.
 //!     //

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -4,10 +4,8 @@ use logos_derive::Logos;
 #[logos(subpattern xdigit = r"[0-9a-fA-F]")]
 #[logos(subpattern a = r"A")]
 #[logos(subpattern b = r"(?&a)BB(?&a)")]
+#[logos(skip r"[ \t\n\f]+")]
 enum Token {
-    #[regex(r"[ \t\n\f]+", logos::skip)]
-    Ignored,
-
     #[regex(r#""([^"\\]|\\t|\\u|\\n|\\")*""#)]
     LiteralString,
 

--- a/tests/tests/callbacks.rs
+++ b/tests/tests/callbacks.rs
@@ -26,10 +26,8 @@ mod data {
 
     #[derive(Logos, Debug, PartialEq)]
     #[logos(error = LexingError)]
+    #[logos(skip r"[ \t\n\f]+")]
     enum Token<'a> {
-        #[regex(r"[ \t\n\f]+", logos::skip)]
-        Ignored,
-
         #[regex(r"[a-zA-Z]+", |lex| lex.slice())]
         Text(&'a str),
 
@@ -65,10 +63,8 @@ mod nested_lifetime {
 
     #[derive(Logos, Debug, PartialEq)]
     #[logos(error = LexingError)]
+    #[logos(skip r"[ \t\n\f]+")]
     enum Token<'a> {
-        #[regex(r"[ \t\n\f]+", logos::skip)]
-        Ignored,
-
         #[regex(r"[0-9]+", |lex| {
             let slice = lex.slice();
 
@@ -116,10 +112,8 @@ mod rust {
 
     #[derive(Logos, Debug, Clone, Copy, PartialEq)]
     #[logos(error = LexingError)]
+    #[logos(skip r"[ \t\n\f]+")]
     enum Token {
-        #[regex(r"[ \t\n\f]+", logos::skip)]
-        Ignored,
-
         #[regex("[a-zA-Z_][a-zA-Z0-9_]*")]
         Ident,
 

--- a/tests/tests/crate_.rs
+++ b/tests/tests/crate_.rs
@@ -9,10 +9,8 @@ mod some {
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
 #[logos(crate = some::path::_logos)]
+#[logos(skip r"[ \t\n\f]+")]
 enum Token {
-    #[regex(r"[ \t\n\f]+", logos::skip)]
-    Ignored,
-
     #[regex("-?[0-9]+")]
     LiteralInteger,
 

--- a/tests/tests/crate_.rs
+++ b/tests/tests/crate_.rs
@@ -8,7 +8,7 @@ mod some {
 }
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
-#[logos(crate = "some::path::_logos")]
+#[logos(crate = some::path::_logos)]
 enum Token {
     #[regex(r"[ \t\n\f]+", logos::skip)]
     Ignored,

--- a/tests/tests/css.rs
+++ b/tests/tests/css.rs
@@ -1,10 +1,8 @@
 use logos_derive::Logos;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
+#[logos(skip r"[ \t\n\f]+")]
 enum Token {
-    #[regex(r"[ \t\n\f]+", logos::skip)]
-    Ignored,
-
     #[regex("em|ex|ch|rem|vw|vh|vmin|vmax")]
     RelativeLength,
 

--- a/tests/tests/edgecase.rs
+++ b/tests/tests/edgecase.rs
@@ -6,10 +6,8 @@ mod crunch {
     use super::*;
 
     #[derive(Logos, Debug, Clone, Copy, PartialEq)]
+    #[logos(skip r"[ \t\n\f]+")]
     enum Token {
-        #[regex(r"[ \t\n\f]+", logos::skip)]
-        Ignored,
-
         #[token("else")]
         Else,
 
@@ -33,10 +31,8 @@ mod numbers {
     use super::*;
 
     #[derive(Logos, Debug, Clone, Copy, PartialEq)]
+    #[logos(skip r"[ \t\n\f]+")]
     enum Token {
-        #[regex(r"[ \t\n\f]+", logos::skip)]
-        Ignored,
-
         #[regex(r"[0-9][0-9_]*")]
         LiteralUnsignedNumber,
 
@@ -76,10 +72,8 @@ mod benches {
     use super::*;
 
     #[derive(Debug, Clone, Copy, PartialEq, Logos)]
+    #[logos(skip r"[ \t\n\f]+")]
     pub enum Token {
-        #[regex(r"[ \t\n\f]+", logos::skip)]
-        InvalidToken,
-
         #[regex("[a-zA-Z_$][a-zA-Z0-9_$]*")]
         Identifier,
 
@@ -223,10 +217,8 @@ mod unicode_whitespace {
     use super::*;
 
     #[derive(Logos, Debug, Clone, Copy, PartialEq)]
+    #[logos(skip r"\p{Whitespace}+")]
     enum Token {
-        #[regex(r"\p{Whitespace}+", logos::skip)]
-        Ignored,
-
         #[regex("[0-9]+")]
         Number,
     }
@@ -248,10 +240,8 @@ mod trivia {
     use super::*;
 
     #[derive(Logos, Debug, Clone, Copy, PartialEq)]
+    #[logos(skip "[a-f]+")]
     enum Token {
-        #[regex("[a-f]+", logos::skip)]
-        Ignored,
-
         #[regex("[0-9]+")]
         Number,
     }
@@ -351,11 +341,9 @@ mod type_params {
         type S = &str,
         type N = u64,
         error = LexingError,
+        skip r"[ \n\t\f]+",
     )]
     enum Token<S, N> {
-        #[regex(r"[ \n\t\f]+", logos::skip)]
-        Ignored,
-
         #[regex("[a-z]+")]
         Ident(S),
 
@@ -385,10 +373,8 @@ mod priority_disambiguate_1 {
     use super::*;
 
     #[derive(Logos, Debug, PartialEq)]
+    #[logos(skip r"[ \n\t\f]+")]
     enum Token {
-        #[regex(r"[ \n\t\f]+", logos::skip)]
-        Ignored,
-
         #[regex("[abc]+", priority = 2)]
         Abc,
 
@@ -408,10 +394,8 @@ mod priority_disambiguate_2 {
     use super::*;
 
     #[derive(Logos, Debug, PartialEq)]
+    #[logos(skip r"[ \n\t\f]+")]
     enum Token {
-        #[regex(r"[ \n\t\f]+", logos::skip)]
-        Ignored,
-
         #[regex("[abc]+")]
         Abc,
 
@@ -431,10 +415,8 @@ mod loop_in_loop {
     use super::*;
 
     #[derive(Logos, Debug, PartialEq)]
+    #[logos(skip r"[ \t\n\f]+")]
     pub enum Token {
-        #[regex(r"[ \t\n\f]+", logos::skip)]
-        Ignored,
-
         #[regex("f(f*oo)*")]
         Foo,
     }
@@ -458,10 +440,8 @@ mod maybe_in_loop {
     use super::*;
 
     #[derive(Logos, Debug, PartialEq)]
+    #[logos(skip r"[ \t\n\f]+")]
     pub enum Token {
-        #[regex(r"[ \t\n\f]+", logos::skip)]
-        Error,
-
         #[regex("f(f?oo)*")]
         Foo,
     }

--- a/tests/tests/ignore_case.rs
+++ b/tests/tests/ignore_case.rs
@@ -1,12 +1,10 @@
 mod ignore_ascii_case {
-    use logos::Logos;
+    use logos_derive::Logos;
     use tests::assert_lex;
 
     #[derive(Logos, Debug, PartialEq, Eq)]
+    #[logos(skip " +")]
     enum Words {
-        #[regex(" +", logos::skip)]
-        Ignored,
-
         #[token("lOwERCaSe", ignore(ascii_case))]
         Lowercase,
         #[token("or", ignore(ascii_case))]
@@ -74,10 +72,8 @@ mod ignore_ascii_case {
     }
 
     #[derive(Logos, Debug, PartialEq, Eq)]
+    #[logos(skip " +")]
     enum Letters {
-        #[regex(" +", logos::skip)]
-        Ignored,
-
         #[regex("a", ignore(ascii_case))]
         Single,
         #[regex("bc", ignore(ascii_case))]
@@ -149,14 +145,13 @@ mod ignore_ascii_case {
 }
 
 mod ignore_case {
-    use logos::Logos;
+    // use logos::Logos as _;
+    use logos_derive::Logos;
     use tests::assert_lex;
 
     #[derive(Logos, Debug, PartialEq, Eq)]
+    #[logos(skip " +")]
     enum Words {
-        #[regex(" +", logos::skip)]
-        Ignored,
-
         #[token("élÉphAnt", ignore(case))]
         Elephant,
         #[token("ÉlèvE", ignore(case))]
@@ -200,10 +195,8 @@ mod ignore_case {
     }
 
     #[derive(Logos, PartialEq, Eq, Debug)]
+    #[logos(skip " +")]
     enum Sink {
-        #[regex(" +", logos::skip)]
-        Ignored,
-
         #[regex("[abcéà]+", ignore(case))]
         Letters,
         #[regex("[0-9]+", ignore(case))]

--- a/tests/tests/properties.rs
+++ b/tests/tests/properties.rs
@@ -5,10 +5,8 @@ mod binary;
 mod custom_error;
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq)]
+#[logos(skip r"[ \t\n\f]+")]
 enum Token {
-    #[regex(r"[ \t\n\f]+", logos::skip)]
-    Ignored,
-
     #[regex(r"[a-zA-Z]+")]
     Ascii,
 

--- a/tests/tests/simple.rs
+++ b/tests/tests/simple.rs
@@ -31,7 +31,6 @@ enum Token {
 
         logos::Skip
     })]
-    Ignored,
 
     #[regex("[a-zA-Z$_][a-zA-Z0-9$_]*")]
     Identifier,

--- a/tests/tests/simple.rs
+++ b/tests/tests/simple.rs
@@ -31,7 +31,6 @@ enum Token {
 
         logos::Skip
     })]
-
     #[regex("[a-zA-Z$_][a-zA-Z0-9$_]*")]
     Identifier,
 


### PR DESCRIPTION
Follow up to the [discussion here](https://github.com/maciejhirsz/logos/pull/273#issuecomment-1445344527).

I'd be keen on some opinions on the syntax here. This might look a bit too magical right now, it's possible that `#[logos(skip regex("..."))]` would be better, so that `token` skips could also be an option.