### PR TITLE
chore(codegen): error to prevent undesired behavior

### DIFF
--- a/logos-codegen/Cargo.toml
+++ b/logos-codegen/Cargo.toml
@@ -18,6 +18,7 @@ syn = { version = "2.0.13", features = ["full"] }
 quote = "1.0.3"
 proc-macro2 = "1.0.9"
 regex-syntax = "0.6"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/logos-codegen/src/mir.rs
+++ b/logos-codegen/src/mir.rs
@@ -110,9 +110,13 @@ impl TryFrom<Hir> for Mir {
                 }
 
                 let kind = repetition.kind;
+                let is_dot = *repetition.hir == Hir::dot(!repetition.hir.is_always_utf8());
                 let mir = Mir::try_from(*repetition.hir)?;
 
                 match kind {
+                    RepetitionKind::ZeroOrMore | RepetitionKind::OneOrMore if is_dot => {
+                Err(r#"#[regex]: ".+" and ".*" regexes will always match everything, which is most propably not what you want. If you are looking to match everything until a specific character, you should use a capturing group. E.g., use regex r"\([^\}]\)" to match anything in between two parentheses. Read more about that here: https://github.com/maciejhirsz/logos/issues/302#issuecomment-1521342541."#.into())
+            }
                     RepetitionKind::ZeroOrOne => Ok(Mir::Maybe(Box::new(mir))),
                     RepetitionKind::ZeroOrMore => Ok(Mir::Loop(Box::new(mir))),
                     RepetitionKind::OneOrMore => {

--- a/logos-codegen/src/mir.rs
+++ b/logos-codegen/src/mir.rs
@@ -128,8 +128,17 @@ impl TryFrom<Hir> for Mir {
 
                 match kind {
                     RepetitionKind::ZeroOrMore | RepetitionKind::OneOrMore if is_dot => {
-                Err(r#"#[regex]: ".+" and ".*" regexes will always match everything, which is most propably not what you want. If you are looking to match everything until a specific character, you should use a capturing group. E.g., use regex r"\([^\}]\)" to match anything in between two parentheses. Read more about that here: https://github.com/maciejhirsz/logos/issues/302#issuecomment-1521342541."#.into())
-            }
+                        Err(
+                            "#[regex]: \".+\" and \".*\" patterns will greedily consume \
+                            the entire source till the end as Logos does not allow \
+                            backtracking. If you are looking to match everything until \
+                            a specific character, you should use a negative character \
+                            class. E.g., use regex r\"'[^']*'\" to match anything in \
+                            between two quotes. Read more about that here: \
+                            https://github.com/maciejhirsz/logos/issues/302#issuecomment-1521342541."
+                            .into()
+                        )
+                    }
                     RepetitionKind::ZeroOrOne => Ok(Mir::Maybe(Box::new(mir))),
                     RepetitionKind::ZeroOrMore => Ok(Mir::Loop(Box::new(mir))),
                     RepetitionKind::OneOrMore => {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,3 +1,87 @@
+//! ```compile_fail
+//! use logos::Logos;
+//! use logos_derive::Logos;
+//!
+//! #[derive(Logos)]
+//! enum Token {
+//!     #[token(b"\xFF")]
+//!     NonUtf8,
+//! }
+//!
+//! fn main() {
+//!     Token::lexer("This shouldn't work with a string literal!");
+//! }
+//! ```
+//!
+//! Same, but with regex:
+//!
+//! ```compile_fail
+//! use logos::Logos;
+//! use logos_derive::Logos;
+//!
+//! #[derive(Logos)]
+//! enum Token {
+//!     #[regex(b"\xFF")]
+//!     NonUtf8,
+//! }
+//!
+//! fn main() {
+//!     Token::lexer("This shouldn't work with a string literal!");
+//! }
+//! ```
+//!
+//! Matching against .* (or .+) should fail to compile:
+//!
+//! ```compile_fail
+//! use logos::Logos;
+//! use logos_derive::Logos;
+//!
+//! #[derive(Logos, Debug, PartialEq)]
+//! enum Token {
+//!     #[regex(r"\(.*\)")]
+//!     BetweenParen,
+//!
+//! }
+//! ```
+//!
+//! ```compile_fail
+//! use logos::Logos;
+//! use logos_derive::Logos;
+//!
+//! #[derive(Logos, Debug, PartialEq)]
+//! enum Token {
+//!     #[regex(r"\(.+\)")]
+//!     BetweenParen,
+//!
+//! }
+//! ```
+//!
+//! And also when working with bytes:
+//!
+//! ```compile_fail
+//! use logos::Logos;
+//! use logos_derive::Logos;
+//!
+//! #[derive(Logos, Debug, PartialEq)]
+//! enum Token {
+//!     #[regex(b"\x00.*")]
+//!     NonUtf8,
+//!
+//! }
+//! ```
+//!
+//! ```compile_fail
+//! use logos::Logos;
+//! use logos_derive::Logos;
+//!
+//! #[derive(Logos, Debug, PartialEq)]
+//! enum Token {
+//!     #[regex(b"\x00.+")]
+//!     NonUtf8,
+//!
+//! }
+//! ```
+
 use logos::source::Source;
 use logos::Logos;
 

--- a/tests/tests/binary.rs
+++ b/tests/tests/binary.rs
@@ -1,34 +1,3 @@
-//! ```compile_fail
-//! use logos::Logos;
-//! use logos_derive::Logos;
-//!
-//! #[derive(Logos)]
-//! enum Token {
-//!     #[token(b"\xFF")]
-//!     NonUtf8,
-//! }
-//!
-//! fn main() {
-//!     Token::lexer("This shouldn't work with a string literal!");
-//! }
-//! ```
-//! Same, but with regex:
-//!
-//! ```compile_fail
-//! use logos::Logos;
-//! use logos_derive::Logos;
-//!
-//! #[derive(Logos)]
-//! enum Token {
-//!     #[regex(b"\xFF")]
-//!     NonUtf8,
-//! }
-//!
-//! fn main() {
-//!     Token::lexer("This shouldn't work with a string literal!");
-//! }
-//! ```
-
 use logos_derive::Logos;
 use tests::assert_lex;
 


### PR DESCRIPTION
Hi @maciejhirsz !

This PR follows what was discussed in #302.

I added a small check in `logos-codegen` to check for `.*` or `.+` patterns. When found, an error is raised with a helpful message that redirects to a solution.

I hope the implementation is correct (especially for non-utf8 cases and the fact that I also added a check for `.+`).

# NOTES

1. I had to move the doc tests from `tests/tests/binary.rs` to `tests/src/lib.rs` because I don't think they were ever executed;
2. I think that the pattern you mentioned in https://github.com/maciejhirsz/logos/issues/302#issuecomment-1521342541, namely `r"\([^)]*\)"`, is missing an `\` to escape the inner `)`;
3. and I added new tests that assert a compile error is raised for the given cases.