### PR TITLE
Use lifetime GAT for Source::Slice

### DIFF
--- a/logos/Cargo.toml
+++ b/logos/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["lexer", "lexical", "tokenizer", "parser", "no_std"]
 categories = ["parsing", "text-processing"]
 readme = "../README.md"
 edition = "2021"
-rust-version = "1.62.1"
+rust-version = "1.65.0"
 
 [dependencies]
 logos-derive = { version = "0.13.0", path = "../logos-derive", optional = true }

--- a/logos/src/lexer.rs
+++ b/logos/src/lexer.rs
@@ -139,13 +139,13 @@ impl<'source, Token: Logos<'source>> Lexer<'source, Token> {
 
     /// Get a string slice of the current token.
     #[inline]
-    pub fn slice(&self) -> &'source <Token::Source as Source>::Slice {
+    pub fn slice(&self) -> <Token::Source as Source>::Slice<'source> {
         unsafe { self.source.slice_unchecked(self.span()) }
     }
 
     /// Get a slice of remaining source, starting at the end of current token.
     #[inline]
-    pub fn remainder(&self) -> &'source <Token::Source as Source>::Slice {
+    pub fn remainder(&self) -> <Token::Source as Source>::Slice<'source> {
         unsafe {
             self.source
                 .slice_unchecked(self.token_end..self.source.len())

--- a/logos/src/source.rs
+++ b/logos/src/source.rs
@@ -15,7 +15,9 @@ use std::ops::Range;
 #[allow(clippy::len_without_is_empty)]
 pub trait Source {
     /// A type this `Source` can be sliced into.
-    type Slice: ?Sized + PartialEq + Eq + Debug;
+    type Slice<'a>: PartialEq + Eq + Debug
+    where
+        Self: 'a;
 
     /// Length of the source
     fn len(&self) -> usize;
@@ -59,7 +61,7 @@ pub trait Source {
     /// let foo = "It was the year when they finally immanentized the Eschaton.";
     /// assert_eq!(<str as Source>::slice(&foo, 51..59), Some("Eschaton"));
     /// ```
-    fn slice(&self, range: Range<usize>) -> Option<&Self::Slice>;
+    fn slice(&self, range: Range<usize>) -> Option<Self::Slice<'_>>;
 
     /// Get a slice of the source at given range. This is analogous to
     /// `slice::get_unchecked(range)`.
@@ -77,7 +79,7 @@ pub trait Source {
     ///     assert_eq!(<str as Source>::slice_unchecked(&foo, 51..59), "Eschaton");
     /// }
     /// ```
-    unsafe fn slice_unchecked(&self, range: Range<usize>) -> &Self::Slice;
+    unsafe fn slice_unchecked(&self, range: Range<usize>) -> Self::Slice<'_>;
 
     /// For `&str` sources attempts to find the closest `char` boundary at which source
     /// can be sliced, starting from `index`.
@@ -96,7 +98,7 @@ pub trait Source {
 }
 
 impl Source for str {
-    type Slice = str;
+    type Slice<'a> = &'a str;
 
     #[inline]
     fn len(&self) -> usize {
@@ -157,7 +159,7 @@ impl Source for str {
 }
 
 impl Source for [u8] {
-    type Slice = [u8];
+    type Slice<'a> = &'a [u8];
 
     #[inline]
     fn len(&self) -> usize {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -89,7 +89,7 @@ pub fn assert_lex<'a, Token>(
     source: &'a Token::Source,
     tokens: &[(
         Result<Token, Token::Error>,
-        &'a <Token::Source as Source>::Slice,
+        <Token::Source as Source>::Slice<'a>,
         Range<usize>,
     )],
 ) where


### PR DESCRIPTION
This is required to write a `Source` impl for any type whose slice is a custom type and not a bare reference. For example, see [`ropey::RopeSlice`](https://docs.rs/ropey/latest/ropey/struct.RopeSlice.html).

Relates to #222.
