### PR TITLE
fix(lib): correctly handle miss for loop in loop

### DIFF
--- a/logos-codegen/src/graph/regex.rs
+++ b/logos-codegen/src/graph/regex.rs
@@ -7,12 +7,12 @@ use crate::mir::{Class, ClassUnicode, Literal, Mir};
 
 impl<Leaf: Disambiguate + Debug> Graph<Leaf> {
     pub fn regex(&mut self, mir: Mir, then: NodeId) -> NodeId {
-        self.parse_mir(mir, then, None, None, false)
+        self.parse_mir(&mir, then, None, None, false)
     }
 
     fn parse_mir(
         &mut self,
-        mir: Mir,
+        mir: &Mir,
         then: NodeId,
         miss: Option<NodeId>,
         reserved: Option<ReservedId>,
@@ -30,7 +30,7 @@ impl<Leaf: Disambiguate + Debug> Graph<Leaf> {
                     // iteration.
                     let reserved_next = self.reserve();
                     new_then = self.parse_mir(
-                        (*mir).clone(),
+                        mir,
                         reserved_next.get(),
                         Some(then),
                         Some(reserved_next),
@@ -42,7 +42,7 @@ impl<Leaf: Disambiguate + Debug> Graph<Leaf> {
                     new_miss = then;
                 }
 
-                self.parse_mir(*mir, new_then, Some(new_miss), Some(reserved_first), true)
+                self.parse_mir(mir, new_then, Some(new_miss), Some(reserved_first), true)
             }
             Mir::Maybe(mir) => {
                 let miss = match miss {
@@ -50,7 +50,7 @@ impl<Leaf: Disambiguate + Debug> Graph<Leaf> {
                     None => then,
                 };
 
-                self.parse_mir(*mir, then, Some(miss), reserved, true)
+                self.parse_mir(mir, then, Some(miss), reserved, true)
             }
             Mir::Alternation(alternation) => {
                 let mut fork = Fork::new().miss(miss);
@@ -69,7 +69,7 @@ impl<Leaf: Disambiguate + Debug> Graph<Leaf> {
 
                 self.insert_or_push(reserved, Rope::new(pattern, then).miss(miss))
             }
-            Mir::Concat(mut concat) => {
+            Mir::Concat(concat) => {
                 // We'll be writing from the back, so need to allocate enough
                 // space here. Worst case scenario is all unicode codepoints
                 // producing 4 byte utf8 sequences
@@ -78,52 +78,50 @@ impl<Leaf: Disambiguate + Debug> Graph<Leaf> {
                 let mut end = ropebuf.len();
                 let mut then = then;
 
-                let mut handle_bytes = |graph: &mut Self, mir, then: &mut NodeId| match mir {
+                let mut handle_bytes = |graph: &mut Self, mir: &Mir, then: &mut NodeId| match mir {
                     Mir::Literal(Literal(bytes)) => {
                         cur -= bytes.len();
                         for (i, byte) in bytes.iter().enumerate() {
                             ropebuf[cur + i] = byte.into();
                         }
-                        None
+                        true
                     }
-                    Mir::Class(Class::Unicode(class)) if is_one_ascii(&class, repeated) => {
+                    Mir::Class(Class::Unicode(class)) if is_one_ascii(class, repeated) => {
                         cur -= 1;
                         ropebuf[cur] = class.ranges()[0].into();
-                        None
+                        true
                     }
                     Mir::Class(Class::Bytes(class)) if class.ranges().len() == 1 => {
                         cur -= 1;
                         ropebuf[cur] = class.ranges()[0].into();
-                        None
+                        true
                     }
-                    mir => {
+                    _ => {
                         if end > cur {
                             let rope = Rope::new(&ropebuf[cur..end], *then);
 
                             *then = graph.push(rope);
                             end = cur;
                         }
-
-                        Some(mir)
+                        false
                     }
                 };
 
-                for mir in concat.drain(1..).rev() {
-                    if let Some(mir) = handle_bytes(self, mir, &mut then) {
+                for mir in concat[1..].iter().rev() {
+                    if !handle_bytes(self, mir, &mut then) {
                         then = self.parse_mir(mir, then, None, None, false);
                     }
                 }
 
-                match handle_bytes(self, concat.remove(0), &mut then) {
-                    None => {
-                        let rope = Rope::new(&ropebuf[cur..end], then).miss(miss);
-
-                        self.insert_or_push(reserved, rope)
-                    }
-                    Some(mir) => self.parse_mir(mir, then, miss, reserved, false),
+                let first_mir = &concat[0];
+                if handle_bytes(self, first_mir, &mut then) {
+                    let rope = Rope::new(&ropebuf[cur..end], then).miss(miss);
+                    self.insert_or_push(reserved, rope)
+                } else {
+                    self.parse_mir(first_mir, then, miss, reserved, false)
                 }
             }
-            Mir::Class(Class::Unicode(class)) if !is_ascii(&class, repeated) => {
+            Mir::Class(Class::Unicode(class)) if !is_ascii(class, repeated) => {
                 let mut ropes = class
                     .iter()
                     .flat_map(|range| Utf8Sequences::new(range.start(), range.end()))

--- a/tests/tests/edgecase.rs
+++ b/tests/tests/edgecase.rs
@@ -424,13 +424,19 @@ mod loop_in_loop {
     #[test]
     fn test_a_loop_in_a_loop() {
         assert_lex(
-            "foo ffoo ffffooffoooo foooo foofffffoo",
+            "foo ffoo ffffooffoooo foooo foofffffoo f ff ffo ffoofo",
             &[
                 (Ok(Token::Foo), "foo", 0..3),
                 (Ok(Token::Foo), "ffoo", 4..8),
                 (Ok(Token::Foo), "ffffooffoooo", 9..21),
                 (Ok(Token::Foo), "foooo", 22..27),
                 (Ok(Token::Foo), "foofffffoo", 28..38),
+                (Ok(Token::Foo), "f", 39..40),
+                (Ok(Token::Foo), "ff", 41..43),
+                (Ok(Token::Foo), "ff", 44..46),
+                (Err(()), "o", 46..47),
+                (Ok(Token::Foo), "ffoof", 48..53),
+                (Err(()), "o", 53..54),
             ],
         );
     }

--- a/tests/tests/edgecase.rs
+++ b/tests/tests/edgecase.rs
@@ -432,10 +432,10 @@ mod loop_in_loop {
                 (Ok(Token::Foo), "foooo", 22..27),
                 (Ok(Token::Foo), "foofffffoo", 28..38),
                 (Ok(Token::Foo), "f", 39..40),
-                (Ok(Token::Foo), "ff", 41..43),
-                (Ok(Token::Foo), "ff", 44..46),
+                (Err(()), "ff", 41..43),
+                (Err(()), "ff", 44..46),
                 (Err(()), "o", 46..47),
-                (Ok(Token::Foo), "ffoof", 48..53),
+                (Err(()), "ffoof", 48..53),
                 (Err(()), "o", 53..54),
             ],
         );


### PR DESCRIPTION
fixes https://github.com/maciejhirsz/logos/issues/392

This PR changes the construction of the graph for a regex `Mir::Loop` when there is a `miss` path present. Given an input that essentially represents this control flow:

```mermaid
flowchart LR
    start-->1
    1((1))--a*-->2((2))
    2((2))--then-->3((3))
    1((1))--miss-->4((4))
```

we previously lowered it to a single loop and unconditionally merged the `then` and old `miss` arms into the new miss of the loop:

```mermaid
flowchart LR
    start-->1((1))
    1((1))--a-->1((1))
    1((1))--_-->2((2))
    2((2))--then-->3((3))
    2((2))--miss-->4((4))
```

This lowering can lead to situations, where we incorrectly match `a` followed by `miss`, even though `a` must be followed by `then`.

This PR solves the issue by generating two separate paths for the first and other iterations of the loop, and merging the `then` and old `miss` only for the new miss of the first iteration path:

```mermaid
flowchart LR
    start-->1
    1((1))--a-->2((2))
    2((2))--a-->2((2))
    2((2))--_-->3((3))
    3((3))--then-->4((4))
    1((1))--_-->5((5))
    5((5))--then-->4((4))
    5((5))--miss-->6((6))
```

Since the path for `a` may be potentially long, this can result in a lot more generated code, especially for deeply nested loops. But I hope that such patterns are rare enough in the wild that we can accept a performance hit for the sake of a correctness fix. For what it's worth, the `cargo bench`es seem to perform similar before and after this patch on my machine.