### PR TITLE
fix(codegen/regex): allow vec growth on parse

### DIFF
--- a/logos-codegen/src/graph/regex.rs
+++ b/logos-codegen/src/graph/regex.rs
@@ -235,26 +235,6 @@ mod tests {
     }
 
     #[test]
-    fn long_concat_389() {
-        let mut graph = Graph::new();
-
-        let mir = Mir::utf8("abcdefghijklmnopqrstuvwxyz*").unwrap();
-
-        assert_eq!(mir.priority(), 50);
-
-        let leaf = graph.push(Node::Leaf("LEAF"));
-        let id = graph.regex(mir, leaf);
-        let sub_id = NodeId(NonZeroU32::new(2).unwrap());
-
-        assert_eq!(
-            graph[id],
-            Node::Rope(Rope::new("abcdefghijklmnopqrstuvwxy", sub_id))
-        );
-
-        assert_eq!(graph[sub_id], Node::Rope(Rope::new("z", sub_id).miss(leaf)))
-    }
-
-    #[test]
     fn repeat() {
         let mut graph = Graph::new();
 
@@ -290,5 +270,25 @@ mod tests {
             graph[id],
             Node::Fork(Fork::new().branch('a'..='z', leaf).miss(leaf)),
         );
+    }
+
+    #[test]
+    fn long_concat_389() {
+        let mut graph = Graph::new();
+
+        let mir = Mir::utf8("abcdefghijklmnopqrstuvwxyz*").unwrap();
+
+        assert_eq!(mir.priority(), 50);
+
+        let leaf = graph.push(Node::Leaf("LEAF"));
+        let id = graph.regex(mir, leaf);
+        let sub_id = NodeId(NonZeroU32::new(2).unwrap());
+
+        assert_eq!(
+            graph[id],
+            Node::Rope(Rope::new("abcdefghijklmnopqrstuvwxy", sub_id))
+        );
+
+        assert_eq!(graph[sub_id], Node::Rope(Rope::new("z", sub_id).miss(leaf)))
     }
 }

--- a/logos-codegen/src/graph/regex.rs
+++ b/logos-codegen/src/graph/regex.rs
@@ -5,8 +5,6 @@ use regex_syntax::utf8::Utf8Sequences;
 use crate::graph::{Disambiguate, Fork, Graph, Node, NodeId, Range, ReservedId, Rope};
 use crate::mir::{Class, ClassUnicode, Literal, Mir};
 
-use super::rope;
-
 impl<Leaf: Disambiguate + Debug> Graph<Leaf> {
     pub fn regex(&mut self, mir: Mir, then: NodeId) -> NodeId {
         self.parse_mir(&mir, then, None, None, false)
@@ -79,7 +77,7 @@ impl<Leaf: Disambiguate + Debug> Graph<Leaf> {
 
                 let mut handle_bytes = |graph: &mut Self, mir: &Mir, then: &mut NodeId| match mir {
                     Mir::Literal(Literal(bytes)) => {
-                        ropebuf.extend(bytes.iter().rev().map(|byte| Into::<Range>::into(byte)));
+                        ropebuf.extend(bytes.iter().rev().map(Into::<Range>::into));
                         true
                     }
                     Mir::Class(Class::Unicode(class)) if is_one_ascii(class, repeated) => {

--- a/logos-codegen/src/graph/regex.rs
+++ b/logos-codegen/src/graph/regex.rs
@@ -72,7 +72,7 @@ impl<Leaf: Disambiguate + Debug> Graph<Leaf> {
             Mir::Concat(concat) => {
                 // Take an initial guess at the capacity - estimates a little worse than an average case
                 // scenario by assuming every concat element is singular but has a full code-point unicode literal.
-                // The only way to get the actual size of the Vec is if 
+                // The only way to get the actual size of the Vec is if every sub-concat node is added up.
                 let mut ropebuf: Vec<Range> = Vec::with_capacity(concat.len() * 4);
                 let mut then = then;
 

--- a/logos-codegen/src/graph/regex.rs
+++ b/logos-codegen/src/graph/regex.rs
@@ -90,7 +90,8 @@ impl<Leaf: Disambiguate + Debug> Graph<Leaf> {
                     }
                     _ => {
                         if !ropebuf.is_empty() {
-                            let rope = Rope::new(ropebuf.iter().cloned().rev().collect::<Vec<_>>(), *then);
+                            let rope =
+                                Rope::new(ropebuf.iter().cloned().rev().collect::<Vec<_>>(), *then);
 
                             *then = graph.push(rope);
                             ropebuf = Vec::with_capacity(concat.len() * 4);
@@ -107,7 +108,8 @@ impl<Leaf: Disambiguate + Debug> Graph<Leaf> {
 
                 let first_mir = &concat[0];
                 if handle_bytes(self, first_mir, &mut then) {
-                    let rope = Rope::new(ropebuf.iter().cloned().rev().collect::<Vec<_>>(), then).miss(miss);
+                    let rope = Rope::new(ropebuf.iter().cloned().rev().collect::<Vec<_>>(), then)
+                        .miss(miss);
                     self.insert_or_push(reserved, rope)
                 } else {
                     self.parse_mir(first_mir, then, miss, reserved, false)
@@ -195,6 +197,8 @@ fn is_one_ascii(class: &ClassUnicode, repeated: bool) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use super::*;
     use crate::graph::Node;
     use pretty_assertions::assert_eq;
@@ -234,12 +238,20 @@ mod tests {
     fn long_concat_389() {
         let mut graph = Graph::new();
 
-        let mir = Mir::utf8("abcdefghijklmn*").unwrap();
+        let mir = Mir::utf8("abcdefghijklmnopqrstuvwxyz*").unwrap();
 
-        assert_eq!(mir.priority(), 26);
+        assert_eq!(mir.priority(), 50);
 
         let leaf = graph.push(Node::Leaf("LEAF"));
         let id = graph.regex(mir, leaf);
+        let sub_id = NodeId(NonZeroU32::new(2).unwrap());
+
+        assert_eq!(
+            graph[id],
+            Node::Rope(Rope::new("abcdefghijklmnopqrstuvwxy", sub_id))
+        );
+
+        assert_eq!(graph[sub_id], Node::Rope(Rope::new("z", sub_id).miss(leaf)))
     }
 
     #[test]

--- a/logos-codegen/src/graph/regex.rs
+++ b/logos-codegen/src/graph/regex.rs
@@ -72,6 +72,7 @@ impl<Leaf: Disambiguate + Debug> Graph<Leaf> {
             Mir::Concat(concat) => {
                 // Take an initial guess at the capacity - estimates a little worse than an average case
                 // scenario by assuming every concat element is singular but has a full code-point unicode literal.
+                // The only way to get the actual size of the Vec is if 
                 let mut ropebuf: Vec<Range> = Vec::with_capacity(concat.len() * 4);
                 let mut then = then;
 


### PR DESCRIPTION
Fixes #389. This *is* less efficient, but it's on codegen.