### PR TITLE
chore(ci): add rustfmt to codecov & exclude fuzz from workspace

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Install rustfmt
+      run: |
+        rustup component add rustfmt
+    
     - name: Generate code coverage
       run: |
         cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target
 /book/book
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
-members = ["logos-cli", "logos-codegen", "logos-derive", "tests", "fuzz"]
+members = ["logos-cli", "logos-codegen", "logos-derive", "tests"]
+exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,16 +1,6 @@
 [package]
 name = "logos-fuzz"
-authors.workspace = true
-categories.workspace = true
-description.workspace = true
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
-readme.workspace = true
-repository.workspace = true
-rust-version.workspace = true
-version.workspace = true
+edition = "2021"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
While adding tests for the safe-only code PR, I noticed that the code coverage action hasn't been able to complete successfully for a while.

Originally this was caused by rustfmt not being available in the container. So this installs it before running coverage.

Additionally, the new fuzz crate was interacting poorly with the other projects in the workspace, causing link errors for both the coverage action and when running `cargo build --workspace`. This is because afl crates must be built with `cargo afl build` so they can link properly. Excluding the fuzz crate from the workspace fixes both issues and also makes sure the fuzzing exports aren't inadvertently enabled on the codegen crate outside of running a fuzz.