### PR TITLE
fix(lib): generate same code on big-endian platforms

### DIFF
--- a/logos-codegen/src/graph/mod.rs
+++ b/logos-codegen/src/graph/mod.rs
@@ -58,8 +58,17 @@ pub trait Disambiguate {
 
 /// Id of a Node in the graph. `NodeId` can be referencing an empty
 /// slot that is going to be populated later in time.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NodeId(NonZeroU32);
+
+impl Hash for NodeId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Always use little-endian byte order for hashing to avoid
+        // different code generation on big-endian platforms due to
+        // iteration over a HashMap
+        state.write(&self.0.get().to_le_bytes())
+    }
+}
 
 impl NodeId {
     fn get(self) -> usize {

--- a/logos-codegen/src/graph/mod.rs
+++ b/logos-codegen/src/graph/mod.rs
@@ -65,7 +65,8 @@ impl Hash for NodeId {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Always use little-endian byte order for hashing to avoid
         // different code generation on big-endian platforms due to
-        // iteration over a HashMap
+        // iteration over a HashMap,
+        // see https://github.com/maciejhirsz/logos/issues/427.
         state.write(&self.0.get().to_le_bytes())
     }
 }


### PR DESCRIPTION
Fix for #427. I verified that the test fails in the same way as in the linked issue, when `to_be_bytes` is used instead, so this must have been the only portability issue that is detected by existing tests.