### PR TITLE
Support callbacks returning Result<Skip>

### DIFF
--- a/book/src/callbacks.md
+++ b/book/src/callbacks.md
@@ -59,6 +59,7 @@ Logos can handle callbacks with following return types:
 | `Option<T>`                                                                       | `Ok(Token::Value(T))` **or** `Err(<Token as Logos>::Error::default())`                              |
 | `Result<T, E>`                                                                    | `Ok(Token::Value(T))` **or** `Err(<Token as Logos>::Error::from(err))`                              |
 | [`Skip`](https://docs.rs/logos/latest/logos/struct.Skip.html)                     | _skips matched input_                                                                               |
+| `Result<Skip, E>`                                                                 | _skips matched input_ **or** `Err(<Token as Logos>::Error::from(err))`                              |
 | [`Filter<T>`](https://docs.rs/logos/latest/logos/enum.Filter.html)                | `Ok(Token::Value(T))` **or** _skips matched input_                                                  |
 | [`FilterResult<T, E>`](https://docs.rs/logos/latest/logos/enum.FilterResult.html) | `Ok(Token::Value(T))` **or** `Err(<Token as Logos>::Error::from(err))` **or** _skips matched input_ |
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -117,6 +117,25 @@ impl<'s, T: Logos<'s>> CallbackResult<'s, (), T> for Skip {
     }
 }
 
+impl<'s, E, T: Logos<'s>> CallbackResult<'s, (), T> for Result<Skip, E>
+where
+    E: Into<T::Error>,
+{
+    #[inline]
+    fn construct<Constructor>(self, _: Constructor, lex: &mut Lexer<'s, T>)
+    where
+        Constructor: Fn(()) -> T,
+    {
+        match self {
+            Ok(_) => {
+                lex.trivia();
+                T::lex(lex);
+            }
+            Err(err) => lex.set(Err(err.into())),
+        }
+    }
+}
+
 impl<'s, P, T: Logos<'s>> CallbackResult<'s, P, T> for Filter<P> {
     #[inline]
     fn construct<Constructor>(self, c: Constructor, lex: &mut Lexer<'s, T>)


### PR DESCRIPTION
This makes it possible to return `Result<Skip>` from callbacks, which seems logical.

Here is an example usage:
```rust
use logos::{Lexer, Logos, Skip};

#[derive(Logos, Debug, PartialEq)]
#[logos(error = String)]
#[logos(skip r"\s*")] // Ignore this regex pattern between tokens
enum Token<'src> {
    #[token("<!--", |lex| skip_comment(lex))]
    XmlComment,

    #[regex("<[a-zA-Z0-9-]+", |lex| &lex.slice()[1..])]
    TagOpen(&'src str),

    #[token("/>")]
    TagClose,
}

fn skip_comment<'src>(lex: &mut Lexer<'src, Token<'src>>) -> Result<Skip, String> {
    let mut open_count = 1;
    loop {
        let rem = lex.remainder();
        let close_pos = rem.find("-->").ok_or_else(|| {
            // this skips the rest of the input, as it all is part of the comment
            lex.bump(rem.len());

            "unterminated comment".to_string()
        })?;
        let open_pos = rem[..close_pos].find("<!--");
        if let Some(open_pos) = open_pos {
            open_count += 1;
            lex.bump(open_pos + 4);
            continue;
        }
        lex.bump(close_pos + 3);
        open_count -= 1;
        if open_count == 0 {
            break;
        }
    }
    Ok(Skip)
}

fn main() {
    let mut lex = Token::lexer(
        r#"   
			<!--- this is a comment <!--nested --> -->
        <tag-name
			<!--- this is a comment inside tag (that's weird, but why not?) -->
			<!--- unterminated 
        />
		"#,
    );

    assert_eq!(lex.next(), Some(Ok(Token::TagOpen("tag-name"))));
    assert_eq!(lex.next(), Some(Err("unterminated comment".to_string())));
    assert_eq!(lex.next(), None);
}
```