### PR TITLE
fix(lib): use precise capturing on 1.82+

### DIFF
--- a/.github/workflows/rustlib.yml
+++ b/.github/workflows/rustlib.yml
@@ -1,8 +1,8 @@
 on:
   pull_request:
     paths:
-    - '**.rs'
-    - '**/Cargo.toml'
+      - "**.rs"
+      - "**/Cargo.toml"
   workflow_dispatch:
 
 name: Library testing
@@ -12,47 +12,51 @@ jobs:
     name: Rustdoc
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v4
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
-    - name: Install nightly toolchain
-      uses: dtolnay/rust-toolchain@nightly
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
 
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
 
-    - name: Check rustdoc build
-      run: RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --features debug -Zunstable-options -Zrustdoc-scrape-examples
+      - name: Check rustdoc build
+        run: RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --features debug -Zunstable-options -Zrustdoc-scrape-examples
 
   tests:
     name: Tests
     strategy:
       matrix:
         rust:
-        - stable
-        - beta
-        - nightly
+          - 1.70.0 # current MSRV
+          - 1.82.0 # precise capturing
+          - stable
+          - beta
+          - nightly
         os:
-        - macos-latest
-        - ubuntu-latest
-        - windows-latest
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
         features:
-        - ""  # default features
-        - "--features forbid_unsafe"
+          - "" # default features
+          - "--features forbid_unsafe"
 
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v4
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
-    - name: Install stable toolchain
-      uses: dtolnay/rust-toolchain@stable
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
 
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
 
-    - name: Check that tests run
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --workspace --verbose ${{ matrix.features }}
+      - name: Check that tests run
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --verbose ${{ matrix.features }}

--- a/.github/workflows/rustlib.yml
+++ b/.github/workflows/rustlib.yml
@@ -1,8 +1,8 @@
 on:
   pull_request:
     paths:
-      - "**.rs"
-      - "**/Cargo.toml"
+    - '**.rs'
+    - '**/Cargo.toml'
   workflow_dispatch:
 
 name: Library testing
@@ -12,51 +12,51 @@ jobs:
     name: Rustdoc
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
+    - name: Checkout sources
+      uses: actions/checkout@v4
 
-      - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
+    - name: Install nightly toolchain
+      uses: dtolnay/rust-toolchain@nightly
 
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+    - name: Cache dependencies
+      uses: Swatinem/rust-cache@v2
 
-      - name: Check rustdoc build
-        run: RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --features debug -Zunstable-options -Zrustdoc-scrape-examples
+    - name: Check rustdoc build
+      run: RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --features debug -Zunstable-options -Zrustdoc-scrape-examples
 
   tests:
     name: Tests
     strategy:
       matrix:
         rust:
-          - 1.70.0 # current MSRV
-          - 1.82.0 # precise capturing
-          - stable
-          - beta
-          - nightly
+        - 1.70.0 # current MSRV
+        - 1.82.0 # precise capturing
+        - stable
+        - beta
+        - nightly
         os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
+        - macos-latest
+        - ubuntu-latest
+        - windows-latest
         features:
-          - "" # default features
-          - "--features forbid_unsafe"
+        - ""  # default features
+        - "--features forbid_unsafe"
 
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
+    - name: Checkout sources
+      uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ matrix.rust }}
+    - name: Install stable toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ matrix.rust }}
 
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+    - name: Cache dependencies
+      uses: Swatinem/rust-cache@v2
 
-      - name: Check that tests run
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --verbose ${{ matrix.features }}
+    - name: Check that tests run
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --verbose ${{ matrix.features }}

--- a/.github/workflows/rustlib.yml
+++ b/.github/workflows/rustlib.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         rust:
-        - 1.70.0 # current MSRV
+        - 1.74.0 # current MSRV
         - 1.82.0 # precise capturing
         - stable
         - beta

--- a/.github/workflows/rustlib.yml
+++ b/.github/workflows/rustlib.yml
@@ -51,6 +51,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust }}
+        components: rustfmt
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [package.metadata]
-msrv = "1.70.0" # Needed to duplicate, because cargo-msrv does not support workspace
+msrv = "1.74.0" # Needed to duplicate, because cargo-msrv does not support workspace
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,10 @@ members = ["logos-cli", "logos-codegen", "logos-derive", "tests", "fuzz"]
 resolver = "2"
 
 [workspace.package]
-authors = ["Maciej Hirsz <hello@maciej.codes>", "Jérome Eertmans (maintainer) <jeertmans@icloud.com>"]
+authors = [
+    "Maciej Hirsz <hello@maciej.codes>",
+    "Jérome Eertmans (maintainer) <jeertmans@icloud.com>",
+]
 categories = ["parsing", "text-processing"]
 description = "Create ridiculously fast Lexers"
 edition = "2021"
@@ -12,7 +15,7 @@ keywords = ["lexer", "lexical", "tokenizer", "parser", "no_std"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/maciejhirsz/logos"
-rust-version = "1.70.0"
+rust-version = "1.74.0"
 version = "0.14.2"
 
 [package]
@@ -30,7 +33,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [package.metadata]
-msrv = "1.70.0"  # Needed to duplicate, because cargo-msrv does not support workspace
+msrv = "1.70.0" # Needed to duplicate, because cargo-msrv does not support workspace
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/logos-codegen/Cargo.toml
+++ b/logos-codegen/Cargo.toml
@@ -11,6 +11,9 @@ syn = { version = "2.0.13", features = ["full"] }
 pretty_assertions = "1.4.0"
 rstest = "0.18.2"
 
+[build-dependencies]
+rustc_version = "0.4.1"
+
 [features]
 # Enables debug messages
 debug = []

--- a/logos-codegen/build.rs
+++ b/logos-codegen/build.rs
@@ -1,0 +1,17 @@
+use rustc_version::{version_meta, Version};
+
+fn main() {
+    let version_meta = version_meta().expect("Could not get Rust version");
+
+    let rustc_version = version_meta.semver;
+    let trimmed_rustc_version = Version::new(
+        rustc_version.major,
+        rustc_version.minor,
+        rustc_version.patch,
+    );
+
+    println!("cargo:rustc-check-cfg=cfg(rust_1_82)");
+    if trimmed_rustc_version >= Version::new(1, 82, 0) {
+        println!("cargo:rustc-cfg=rust_1_82");
+    }
+}

--- a/logos-codegen/build.rs
+++ b/logos-codegen/build.rs
@@ -10,6 +10,10 @@ fn main() {
         rustc_version.patch,
     );
 
+    // Add cfg flag for Rust >= 1.82
+    // Required for precise capturing in edition 2024
+    // Due to changes in lifetime and type capture behavior for impl trait
+    // see: https://github.com/maciejhirsz/logos/issues/434, https://github.com/rust-lang/rfcs/pull/3498
     println!("cargo:rustc-check-cfg=cfg(rust_1_82)");
     if trimmed_rustc_version >= Version::new(1, 82, 0) {
         println!("cargo:rustc-cfg=rust_1_82");

--- a/logos-codegen/src/generator/leaf.rs
+++ b/logos-codegen/src/generator/leaf.rs
@@ -32,7 +32,7 @@ impl<'a> Generator<'a> {
                 let ret = quote!(impl CallbackResult<'s, #ty, #this>);
 
                 #[cfg(rust_1_82)]
-                let ret = quote!(impl CallbackResult<'s, #ty, #this> + use<'a>);
+                let ret = quote!(impl CallbackResult<'s, #ty, #this> + use<'s>);
 
                 quote! {
                     #bump

--- a/logos-codegen/src/generator/leaf.rs
+++ b/logos-codegen/src/generator/leaf.rs
@@ -28,11 +28,17 @@ impl<'a> Generator<'a> {
                 let arg = &inline.arg;
                 let body = &inline.body;
 
+                #[cfg(not(rust_1_82))]
+                let ret = quote!(impl CallbackResult<'s, #ty, #this>);
+
+                #[cfg(rust_1_82)]
+                let ret = quote!(impl CallbackResult<'s, #ty, #this> + use<'a>);
+
                 quote! {
                     #bump
 
                     #[inline]
-                    fn callback<'s>(#arg: &mut Lexer<'s>) -> impl CallbackResult<'s, #ty, #this> {
+                    fn callback<'s>(#arg: &mut Lexer<'s>) -> #ret {
                         #body
                     }
 


### PR DESCRIPTION
Fixes https://github.com/maciejhirsz/logos/issues/434 by conditionally adding `+ use<'s>` to the implementation of the callback, but _only_ if on 1.82+

Additionally it adds tests for the MSRV and 1.82 to the CI.