### PR TITLE
Bump rstest to 0.23.0, the current release

### DIFF
--- a/logos-codegen/Cargo.toml
+++ b/logos-codegen/Cargo.toml
@@ -9,7 +9,7 @@ syn = { version = "2.0.13", features = ["full"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
-rstest = "0.18.2"
+rstest = "0.23.0"
 
 [features]
 # Enables debug messages


### PR DESCRIPTION
I confirmed that `cargo test --workspace` still works.