### PR TITLE
chore(release): bump to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/maciejhirsz/logos"
 rust-version = "1.74.0"
-version = "0.14.3"
+version = "0.15.0"
 
 [package]
 name = "logos"
@@ -67,7 +67,7 @@ bench = {lto = true}
 release = {lto = true}
 
 [dependencies]
-logos-derive = {version = "0.14.3", path = "./logos-derive", optional = true}
+logos-derive = {version = "0.15.0", path = "./logos-derive", optional = true}
 
 [dev-dependencies]
 ariadne = {version = "0.4", features = ["auto-color"]}

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -4,7 +4,7 @@
 
 ```toml
 [dependencies]
-logos = "0.14.3"
+logos = "0.15.0"
 ```
 
 Then, you can automatically derive the [`Logos`](https://docs.rs/logos/latest/logos/trait.Logos.html) trait on your `enum` using the `Logos` derive macro:

--- a/logos-cli/Cargo.toml
+++ b/logos-cli/Cargo.toml
@@ -2,7 +2,7 @@
 anyhow = "1.0.57"
 clap = {version = "3.1.18", features = ["derive"]}
 fs-err = "2.7.0"
-logos-codegen = {version = "0.14.3", path = "../logos-codegen"}
+logos-codegen = {version = "0.15.0", path = "../logos-codegen"}
 proc-macro2 = "1.0.39"
 
 [dev-dependencies]

--- a/logos-derive/Cargo.toml
+++ b/logos-derive/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-logos-codegen = {version = "0.14.3", path = "../logos-codegen"}
+logos-codegen = {version = "0.15.0", path = "../logos-codegen"}
 
 [features]
 # Enables debug messages


### PR DESCRIPTION
Release 0.14.3 as 0.15, as it bumped the MSRV, see #449.
