### PR TITLE
docs(calculator_example): bumps `chumsky` crate from 0.9.0 to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ logos-derive = {version = "0.15.0", path = "./logos-derive", optional = true}
 
 [dev-dependencies]
 ariadne = {version = "0.4", features = ["auto-color"]}
-chumsky = {version = "0.9.3" }
+chumsky = {version = "0.10.0" }
 
 [[example]]
 doc-scrape-examples = true  # Only needed once, because requires dev-dependencies


### PR DESCRIPTION
#439 added a simple calculator example to the book, and the example used [`chumsky`](https://github.com/zesterer/chumsky) crate as a parser combinator library.

Recently, [`chumsky` v0.10.0 was released](https://github.com/zesterer/chumsky/releases/tag/0.10) so I upgrade the dependency in this PR.
Please note the crate is only used in the example (I checked `rg chumsky` at the root of the repository).

## References

- [release note of v0.10.0](https://github.com/zesterer/chumsky/releases/tag/0.10)

- zesterer/chumsky#745

- zesterer/chumsky#746

---

I'm creating this PR as a draft... I'll add some comments to the diff.