### PR TITLE
Mark read_byte as unsafe and add safety comments

### DIFF
--- a/logos-codegen/src/generator/context.rs
+++ b/logos-codegen/src/generator/context.rs
@@ -59,20 +59,22 @@ impl Context {
         self.available.saturating_sub(self.at)
     }
 
+    /// Reads the next byte without checking bounds.
+    ///
+    /// # Safety
+    /// The caller must ensure that the next byte is within bounds.
+    #[cfg(not(feature = "forbid_unsafe"))]
+    pub unsafe fn read_byte(&mut self) -> TokenStream {
+        let at = self.at;
+        self.advance(1);
+        quote!(unsafe { lex.read_byte_unchecked(#at) })
+    }
+
+    #[cfg(feature = "forbid_unsafe")]
     pub fn read_byte(&mut self) -> TokenStream {
         let at = self.at;
-
         self.advance(1);
-
-        #[cfg(not(feature = "forbid_unsafe"))]
-        {
-            quote!(unsafe { lex.read_byte_unchecked(#at) })
-        }
-
-        #[cfg(feature = "forbid_unsafe")]
-        {
-            quote!(lex.read_byte(#at))
-        }
+        quote!(lex.read_byte(#at))
     }
 
     pub fn read(&mut self, len: usize) -> TokenStream {

--- a/logos-codegen/src/generator/fork.rs
+++ b/logos-codegen/src/generator/fork.rs
@@ -136,6 +136,12 @@ impl Generator<'_> {
         let min_read = self.meta[this].min_read;
 
         if ctx.remainder() >= max(min_read, 1) {
+            // SAFETY: The read_byte below is safe because the if statement
+            // above checks it's still within bounds.
+            #[cfg(not(feature = "forbid_unsafe"))]
+            let read = unsafe { ctx.read_byte() };
+
+            #[cfg(feature = "forbid_unsafe")]
             let read = ctx.read_byte();
 
             return (quote!(byte), quote!(let byte = #read;));


### PR DESCRIPTION
When forbid_unsafe is enabled, read_byte requires callers to check the next read is still within bounds for it to be safe.