### PR TITLE
Fix #488

### DIFF
--- a/logos-codegen/src/lib.rs
+++ b/logos-codegen/src/lib.rs
@@ -97,7 +97,7 @@ pub fn generate(input: TokenStream) -> TokenStream {
         let field = match &mut variant.fields {
             Fields::Unit => MaybeVoid::Void,
             Fields::Unnamed(fields) => {
-                if fields.unnamed.len() != 1 {
+                let [ref mut field] = *fields.unnamed.iter_mut().collect::<Box<[_]>>() else {
                     parser.err(
                         format!(
                             "Logos currently only supports variants with one field, found {}",
@@ -106,14 +106,9 @@ pub fn generate(input: TokenStream) -> TokenStream {
                         fields.span(),
                     );
                     continue;
-                }
+                };
 
-                let ty = &mut fields
-                    .unnamed
-                    .first_mut()
-                    .expect("Already checked len; qed")
-                    .ty;
-                let ty = parser.get_type(ty);
+                let ty = parser.get_type(&mut field.ty);
 
                 MaybeVoid::Some(ty)
             }

--- a/logos-codegen/src/lib.rs
+++ b/logos-codegen/src/lib.rs
@@ -105,6 +105,7 @@ pub fn generate(input: TokenStream) -> TokenStream {
                         ),
                         fields.span(),
                     );
+                    continue;
                 }
 
                 let ty = &mut fields

--- a/logos-codegen/tests/codegen.rs
+++ b/logos-codegen/tests/codegen.rs
@@ -9,6 +9,8 @@ use std::{error::Error, path::PathBuf};
 #[case("error_callback0")]
 #[case("error_callback1")]
 #[case("error_callback_failure")]
+#[case("tuple_variant_failure0")]
+#[case("tuple_variant_failure1")]
 pub fn test_codegen(#[case] fixture: &str) -> Result<(), Box<dyn Error>> {
     let mut fixture_dir = PathBuf::new();
     fixture_dir.push(env!("CARGO_MANIFEST_DIR"));

--- a/logos-codegen/tests/data/codegen/tuple_variant_failure0/input.rs
+++ b/logos-codegen/tests/data/codegen/tuple_variant_failure0/input.rs
@@ -1,0 +1,5 @@
+#[derive(Logos)]
+enum Token {
+    #[regex(r"\d+")]
+    Integer(),
+}

--- a/logos-codegen/tests/data/codegen/tuple_variant_failure1/input.rs
+++ b/logos-codegen/tests/data/codegen/tuple_variant_failure1/input.rs
@@ -1,0 +1,5 @@
+#[derive(Logos)]
+enum Token<'src> {
+    #[regex(r"\d+.\d+")]
+    Decimal(&'src str, &'src str),
+}

--- a/logos-codegen/tests/snapshots/codegen__tuple_variant_failure0-1_82.snap.new
+++ b/logos-codegen/tests/snapshots/codegen__tuple_variant_failure0-1_82.snap.new
@@ -1,0 +1,6 @@
+---
+source: logos-codegen/tests/codegen.rs
+assertion_line: 28
+expression: generated
+---
+impl < 's > :: logos :: Logos < 's > for Token { type Error = () ; type Extras = () ; type Source = str ; fn lex (lex : & mut :: logos :: Lexer < 's , Self >) { fn _logos_derive_compile_errors () { { compile_error ! ("Logos currently only supports variants with one field, found 0") } } } }

--- a/logos-codegen/tests/snapshots/codegen__tuple_variant_failure1-1_82.snap
+++ b/logos-codegen/tests/snapshots/codegen__tuple_variant_failure1-1_82.snap
@@ -1,0 +1,5 @@
+---
+source: logos-codegen/tests/codegen.rs
+expression: generated
+---
+impl < 's > :: logos :: Logos < 's > for Token < 's > { type Error = () ; type Extras = () ; type Source = str ; fn lex (lex : & mut :: logos :: Lexer < 's , Self >) { fn _logos_derive_compile_errors () { { compile_error ! ("Logos currently only supports variants with one field, found 2") } } } }


### PR DESCRIPTION
First adds 2 test snapshots (tuple variants with {0,2} items), then fixes the panic for the former. The last commit is possibly more controversial: It removes the `.expect` call that caused the panic in the first place (but not the bug!) by instead using pattern matching to check for the length while also getting the value.

Should not be a breaking change, only a cosmetic one (the error message gets more comprehensible).