### PR TITLE
Bump rstest to 0.26.1, the current release

### DIFF
--- a/logos-codegen/Cargo.toml
+++ b/logos-codegen/Cargo.toml
@@ -9,7 +9,7 @@ syn = { version = "2.0.13", features = ["full"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
-rstest = "0.23.0"
+rstest = "0.26.1"
 insta = "1.41.1"
 
 [build-dependencies]


### PR DESCRIPTION
I confirmed that `cargo test` still works in `logos-codegen/`.

https://github.com/la10736/rstest/blob/v0.26.1/CHANGELOG.md