### PR TITLE
Use `package.include` in all published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ readme = "README.md"
 repository = "https://github.com/maciejhirsz/logos"
 rust-version = "1.74.0"
 version = "0.15.1"
+include = ["build.rs", "/src/", "/examples/", "/tests/", "LICENSE-MIT", "LICENSE-APACHE"]
 
 [package]
 name = "logos"
@@ -32,6 +33,7 @@ readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
+include.workspace = true
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/logos-cli/Cargo.toml
+++ b/logos-cli/Cargo.toml
@@ -27,6 +27,7 @@ readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
+include.workspace = true
 
 [package.metadata.release]
 shared-version = true

--- a/logos-codegen/Cargo.toml
+++ b/logos-codegen/Cargo.toml
@@ -39,6 +39,7 @@ readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
+include.workspace = true
 
 [package.metadata.release]
 shared-version = true

--- a/logos-derive/Cargo.toml
+++ b/logos-derive/Cargo.toml
@@ -24,6 +24,7 @@ readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
+include.workspace = true
 
 [package.metadata.release]
 shared-version = true


### PR DESCRIPTION
I came across the issue that the whole `mdbook` is included in the published crates during a dependency review, but `logos.png` is especially big and doesn't have to be included for everything to build.

This PR makes use of [`package.include`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields) to not package these files.  
The excluded files based on the current version would be: `RELEASE-PROCESS.md`, `book/**`, `examples/**`, `logos.{svg,png}`, `release.toml`, `tests/**` and `logos-{codegen,cli}/tests/**`.

This reduces the size of almost all crates, but especially `logos` (note the change in units):

| crate | full without `package.include` | compressed | full with `package.include` | compressed |
|--------|--------|--------|--------|--------|
| `logos-codegen` | 275.1KiB | 54.8KiB | 211.0KiB | 49.3KiB |
| `logos-derive` | 20.4KiB | 8.0KiB | 20.5KiB | 8.0KiB |
| `logos` | 1.8MiB | 1.6MiB | 59.0KiB | 18.9KiB |
| `logos-cli` | 48.5KiB | 15.5KiB | 41.4KiB | 14.1KiB |

Changes of data used (using the number of downloads of the previous version, as of 2025-8-20):

| crate | per download | number of downloads per month | bandwidth/month
|--------|--------|--------|--------|
| `logos-codegen` | -5.5KiB | 149416 | -802.5MiB |
| `logos-derive` | ±0.0KiB | 149368 | ±0.0KiB |
| `logos` | -1.6MiB | 149522 | -233.6GiB |
| `logos-cli` | -1.4KiB | 90 | -126.0KiB |

Though it should be noted that older versions also see a lot of downloads as well, so if the same holds for future versions, the actual bandwidth usage decrease would be much more pronounced over time.  
Using _all_ versions over the last 90 days, the `logos` crate would end up with around 2.0TiB/month less bandwidth usage.