### PR TITLE
Replace "it's" with "its" where it is possessive

### DIFF
--- a/book/src/callbacks.md
+++ b/book/src/callbacks.md
@@ -25,7 +25,7 @@ enum Token {
     // Callbacks can use closure syntax, or refer
     // to a function defined elsewhere.
     //
-    // Each pattern can have it's own callback.
+    // Each pattern can have its own callback.
     #[regex("[0-9]+", |lex| lex.slice().parse().ok())]
     #[regex("[0-9]+k", kilo)]
     #[regex("[0-9]+m", mega)]

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -18,7 +18,7 @@ seeks to remedy this!
 
 There are two main types in **Logos**:
 
-+ The `Logos` trait, which comes out with it's own derive macro. The derive
++ The `Logos` trait, which comes out with its own derive macro. The derive
   macro uses custom attributes (the things using these brackets: `#[...]`)
   with plain string or [regular expression](https://en.wikipedia.org/wiki/Regular_expression)
   syntax on `enum` variants as _patterns_ for some input.

--- a/book/src/token-disambiguation.md
+++ b/book/src/token-disambiguation.md
@@ -21,7 +21,7 @@ Loops or optional blocks are ignored, while alternations count the shortest alte
 + `[a-zA-Z]+` has a priority of 2 (lowest possible), because at minimum it can
   match a single byte to a class;
 + `foobar` has a priority of 12;
-+ and `(foo|hello)(bar)?` has a priority of 6, `foo` being it's shortest possible match.
++ and `(foo|hello)(bar)?` has a priority of 6, `foo` being its shortest possible match.
 
 Generally speaking, equivalent regex patterns have the same priority. E.g.,
 `a|b` is equivalent to `[a-b]`, and both have a priority of 2.


### PR DESCRIPTION
When "its" means something belonging to it, we omit its apostrophe. This is an incredibly confusing rule, but it's the rule :-)

More info: https://dictionary.cambridge.org/grammar/british-grammar/it-s-or-its