### PR TITLE
fix(ci): upload correct build artifacts

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v4
       with:
-        path: ./book/book
+        path: ./book/book/html
 
   # Deployment job
   deploy:


### PR DESCRIPTION
HTML build artifacts are now inside a nested folder, probably because we updated mdBook or because `linkcheck2` creates other build artifacts, see #491.

Closes #516
