### PR TITLE
Remove duplicate Logos import from doctests in tests/lib.rs

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,5 +1,5 @@
 //! ```compile_fail
-//! use logos::Logos;
+//! use logos_derive::Logos;
 //!
 //! #[derive(Logos)]
 //! enum Token {
@@ -13,7 +13,7 @@
 //! Same, but with regex:
 //!
 //! ```compile_fail
-//! use logos::Logos;
+//! use logos_derive::Logos;
 //!
 //! #[derive(Logos)]
 //! enum Token {
@@ -27,7 +27,7 @@
 //! And also when working with bytes:
 //!
 //! ```compile_fail
-//! use logos::Logos;
+//! use logos_derive::Logos;
 //!
 //! #[derive(Logos, Debug, PartialEq)]
 //! enum Token {
@@ -38,7 +38,7 @@
 //! ```
 //!
 //! ```compile_fail
-//! use logos::Logos;
+//! use logos_derive::Logos;
 //!
 //! #[derive(Logos, Debug, PartialEq)]
 //! enum Token {
@@ -52,7 +52,7 @@
 //! When debug is not enabled, this also should not compile.
 //!
 //! ```compile_fail
-//! use logos::Logos;
+//! use logos_derive::Logos;
 //!
 //! #[derive(Logos)]
 //! #[logos(export_dir = "target/tmp")]
@@ -63,7 +63,7 @@
 //! A ".+" pattern shouldn't compile without `allow_greedy = true`
 //!
 //! ```compile_fail
-//! use logos::Logos;
+//! use logos_derive::Logos;
 //!
 //! #[derive(Logos)]
 //! enum Token {
@@ -75,7 +75,7 @@
 //! A ".+" pattern should compile with `allow_greedy = true`
 //!
 //! ```
-//! use logos::Logos;
+//! use logos_derive::Logos;
 //!
 //! #[derive(Logos)]
 //! enum Token {
@@ -87,7 +87,7 @@
 //! https://github.com/maciejhirsz/logos/issues/232
 //! This example fails because the subpattern can match the empty string,
 //! ```compile_fail
-//! use logos::Logos;
+//! use logos_derive::Logos;
 //!
 //! #[derive(Logos)]
 //! #[logos(subpattern example = r"(a|)+")]
@@ -106,9 +106,9 @@
 //!
 //! This example fails because it has a priority conflict
 //! ```compile_fail
-//! use logos::Logos;
+//! use logos_derive::Logos;
 //!
-//! #[derive(logos::Logos)]
+//! #[derive(logos_derive::Logos)]
 //! enum Tokens {
 //!     #[regex(r#"'(?:'?(?:[[:ascii:][^\\']]|\\[[:ascii:]]))*'"#)]
 //!     #[regex(r#"'(?:"?(?:[[:ascii:][^\\"]]|\\[[:ascii:]]))*'"#)]


### PR DESCRIPTION
While reading through the book's guidelines on contributing, it [suggested](https://logos.maciej.codes/contributing/setup.html) that I run `cargo test --workspace`. This command failed however, due to these doctests importing Logos both from `logos` and `logos_derive`. 

I removed those double imports and now it's all good :)

Before
<img width="710" height="465" alt="image" src="https://github.com/user-attachments/assets/76ec31b8-9170-4fa3-a449-3a41f9002cb1" />
After
<img width="1154" height="389" alt="image" src="https://github.com/user-attachments/assets/2769569f-a34a-4150-bf9b-35f0f909c0e4" />
