### PR TITLE
State machine codegen code example swap

### DIFF
--- a/book/src/state-machine-codegen.md
+++ b/book/src/state-machine-codegen.md
@@ -13,23 +13,6 @@ inside of a loop, and state transitions are implemented by assigning to the
 current state variable and then `continue`ing to the start of the loop again.
 
 ```rust,no_run,noplayground
-fn state0(lexer: Lexer, context: Context) -> Token {
-    match lexer.read() {
-        'a' => state1(lexer, context),
-        'b' => state2(lexer, context),
-        _ => Token::Error,
-    }
-}
-
-// Etc ...
-```
-
-## Feature Disabled
-
-The tailcall code generation creates functions for each state, and state
-transitions are implemented by calling the next state's function.
-
-```rust,no_run,noplayground
 let mut state = State::State0;
 loop {
     match state {
@@ -43,6 +26,23 @@ loop {
         // Etc...
     }
 }
+```
+
+## Feature Disabled
+
+The tailcall code generation creates functions for each state, and state
+transitions are implemented by calling the next state's function.
+
+```rust,no_run,noplayground
+fn state0(lexer: Lexer, context: Context) -> Token {
+    match lexer.read() {
+        'a' => state1(lexer, context),
+        'b' => state2(lexer, context),
+        _ => Token::Error,
+    }
+}
+
+// Etc ...
 ```
 
 ## Considerations


### PR DESCRIPTION
I was reading your mdbook and noticed the text explaining state machine codegen didn't match the example code. So I swapped the example code snippets to match the text. I _think_ this is the correct swap, and it wasn't the explanatory text that should have been swapped, but maybe double check ;)

Aside: The considerations part says "The tailcall code generation is significantly faster". Do you mean the time it takes to generate the tailcall code is significantly shorter than the time it takes to generate the state machine code? Or do you mean that the generated tailcall code will execute significantly faster than the generated state machine code? If it's the former, I'd also be very interested in any insights you might have as why that is. I would expect a state machine to be easier for the Rust compiler to compile down into fast machine code than function calls.