### PR TITLE
chore: remove unused dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,12 +95,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,12 +382,6 @@ name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "difflib"
@@ -739,17 +727,14 @@ dependencies = [
 name = "logos-codegen"
 version = "0.16.0"
 dependencies = [
- "beef",
  "fnv",
  "insta",
- "pretty_assertions",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
  "rstest",
- "rustc_version",
  "syn 2.0.104",
 ]
 
@@ -878,16 +863,6 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
 ]
 
 [[package]]

--- a/logos-codegen/Cargo.toml
+++ b/logos-codegen/Cargo.toml
@@ -1,5 +1,4 @@
 [dependencies]
-beef = "0.5.0"
 fnv = "1.0.6"
 proc-macro2 = "1.0.9"
 quote = "1.0.3"
@@ -8,13 +7,9 @@ regex-syntax = "0.8.5"
 syn = { version = "2.0.13", features = ["full"] }
 
 [dev-dependencies]
-pretty_assertions = "1.4.0"
 rstest = "0.26.1"
 insta = "1.41.1"
 prettyplease = "0.2.36"
-
-[build-dependencies]
-rustc_version = "0.4.1"
 
 [features]
 # Enables debug messages

--- a/logos-codegen/src/error.rs
+++ b/logos-codegen/src/error.rs
@@ -1,7 +1,7 @@
-use beef::lean::Cow;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use quote::{quote_spanned, ToTokens, TokenStreamExt};
+use std::borrow::Cow;
 
 #[derive(Default)]
 pub struct Errors {

--- a/logos-codegen/src/parser/mod.rs
+++ b/logos-codegen/src/parser/mod.rs
@@ -1,6 +1,6 @@
-use beef::lean::Cow;
 use proc_macro2::{Span, TokenStream, TokenTree};
 use quote::quote;
+use std::borrow::Cow;
 use syn::spanned::Spanned;
 use syn::{Attribute, GenericParam, Ident, Lit, LitBool, Meta, Type};
 


### PR DESCRIPTION
cc @jeertmans 

`pretty_assertions` and `rustc_version` are purely unused.

I'm trying to replace `beef` with std's Cow. I know `beef` is paired with logos with the same author, but it seems we don't use `beef` in the critical path, so perhaps it's worth trading off for less dependency.

Drop the PR and see your feedback.