### PR TITLE
Fix: Clamp offset in end_to_boundary to prevent UB

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -309,7 +309,14 @@ where
     /// Guarantee that `token_end` is at char boundary for `&str`.
     #[inline]
     fn end_to_boundary(&mut self, offset: usize) {
-        self.token_end = self.source.find_boundary(offset);
+        // Clamp offset to source length to avoid undefined behavior in find_boundary
+        // when is_char_boundary is called with an index beyond the source length.
+        let len = self.source.len();
+        self.token_end = if offset >= len {
+            len
+        } else {
+            self.source.find_boundary(offset)
+        };
     }
 
     #[inline]


### PR DESCRIPTION
When end_to_boundary is called with an offset that exceeds the source length, find_boundary would call is_char_boundary with an out-of-bounds index. For str sources, this is undefined behavior in Rust since is_char_boundary only guarantees correct results for indices <= len. This fix clamps the offset to the source length before calling find_boundary, preventing any potential UB and ensuring the error token span remains valid.