### PR TITLE
Clamp offset in end_to_boundary to prevent infinite loop

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -309,7 +309,10 @@ where
     /// Guarantee that `token_end` is at char boundary for `&str`.
     #[inline]
     fn end_to_boundary(&mut self, offset: usize) {
-        self.token_end = self.source.find_boundary(offset);
+        // Clamp offset to prevent infinite loop in `find_boundary` when
+        // offset exceeds source length (str::is_char_boundary returns false
+        // for indices past the end of the string).
+        self.token_end = self.source.find_boundary(offset.min(self.source.len()));
     }
 
     #[inline]


### PR DESCRIPTION
**Issue:** Calling end_to_boundary with an offset exceeding the source length causes an infinite loop in ind_boundary for &str sources, since str::is_char_boundary returns false for all indices past the end of the string.

**Fix:** Clamp the offset to source.len() before passing it to ind_boundary, ensuring the search terminates at a valid boundary.

- Changed self.source.find_boundary(offset) to self.source.find_boundary(offset.min(self.source.len())) in end_to_boundary.
- Prevents infinite loop when 	oken_end is set to a value beyond the source length.