### PR TITLE
impl fmt::Debug on Lexer: use debug_struct

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -27,10 +27,10 @@ where
     Token::Extras: Debug,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_map()
-            .entry(&"source", &self.source)
-            .entry(&"extras", &self.extras)
-            .finish()
+        fmt.debug_struct("Lexer")
+            .field("source", &self.source)
+            .field("extras", &self.extras)
+            .finish_non_exhaustive()
     }
 }
 

--- a/tests/tests/simple.rs
+++ b/tests/tests/simple.rs
@@ -2,7 +2,7 @@ use logos::Lexer;
 use logos::Logos;
 use tests::assert_lex;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct MockExtras {
     spaces: usize,
     line_breaks: usize,
@@ -406,4 +406,12 @@ fn uints() {
     assert_eq!(lex.extras.byte_size, 4);
 
     assert_eq!(lex.next(), None);
+}
+
+#[test]
+fn debug() {
+    assert_eq!(
+        format!("{:?}", Token::lexer("")),
+        "Lexer { source: \"\", extras: MockExtras { spaces: 0, line_breaks: 0, numbers: 0, byte_size: 0 }, .. }"
+    );
 }


### PR DESCRIPTION
Closer to what `#[derive(Debug)]` would do


Before:
```
{"source": "", "extras": MockExtras { spaces: 0, line_breaks: 0, numbers: 0, byte_size: 0 }}
```

After:
```
Lexer { source: "", extras: MockExtras { spaces: 0, line_breaks: 0, numbers: 0, byte_size: 0 }, .. }
```