### PR TITLE
docs: add incomplete input example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,3 +103,7 @@ path = "examples/json.rs"
 [[example]]
 name = "json-borrowed"
 path = "examples/json_borrowed.rs"
+
+[[example]]
+name = "partial_input"
+path = "examples/partial_input.rs"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -10,6 +10,7 @@
 + [Using `Extras`](./extras.md)
 + [Using callbacks](./callbacks.md)
 + [Context-dependent lexing](./context-dependent-lexing.md)
++ [Handling incomplete input](./incomplete-input.md)
 + [Common regular expressions](./common-regex.md)
 + [Unicode support](./unicode-support.md)
 + [State machine codegen](./state-machine-codegen.md)

--- a/book/src/examples.md
+++ b/book/src/examples.md
@@ -13,3 +13,6 @@ The following examples are ordered by increasing level of complexity.
 **[JSON-borrowed parser](./examples/json_borrowed.md)**: A variant of the previous parser, but that does not own its data.
 
 **[String interpolation](./examples/string-interpolation.md)**: Example on using context-dependent lexing to parse a simple language with string interpolation.
+
+The [handling incomplete input](./incomplete-input.md) page also includes a
+small example for language-server and streaming-parser style use cases.

--- a/book/src/incomplete-input.md
+++ b/book/src/incomplete-input.md
@@ -1,0 +1,26 @@
+# Handling incomplete input
+
+Logos lexers operate on the source slice they receive. If that slice ends while
+the next token may still grow, the lexer cannot tell whether the input is truly
+finished or whether more bytes will arrive later.
+
+For interactive editors, language servers, and sans-I/O parsers, a practical
+pattern is to model known incomplete forms as explicit tokens. The parser can
+then decide whether to report an unfinished construct, keep buffering from the
+token span, or request more input from the caller.
+
+The example below accepts complete tags like `<ready>`, but emits
+`IncompleteTag` for a tag-like prefix that reaches the end of the provided
+source:
+
+```rust
+{{#include ../../examples/partial_input.rs:all}}
+```
+
+In an editor, `IncompleteTag` can become a recoverable diagnostic. In a
+streaming parser, the span from `spanned()` identifies the bytes that should be
+kept in the buffer before reading more input.
+
+This does not replace a dedicated partial-lexing API. It is a useful approach
+when the incomplete shapes are known from the grammar and can be represented as
+ordinary Logos token definitions.

--- a/examples/partial_input.rs
+++ b/examples/partial_input.rs
@@ -1,0 +1,35 @@
+//! Pattern for handling incomplete input with an explicit token.
+//!
+//! Usage:
+//!     cargo run --example partial_input
+
+/* ANCHOR: all */
+use logos::Logos;
+
+#[derive(Debug, Logos, PartialEq)]
+#[logos(skip r"[ \t\r\n]+")]
+enum Token<'source> {
+    #[regex(r"<[^>]*>", |lex| lex.slice())]
+    Tag(&'source str),
+
+    #[regex(r"<[^>]*")]
+    IncompleteTag,
+
+    #[regex(r"[^<\s]+", |lex| lex.slice())]
+    Text(&'source str),
+}
+
+fn main() {
+    let mut complete = Token::lexer("open <ready>");
+
+    assert_eq!(complete.next(), Some(Ok(Token::Text("open"))));
+    assert_eq!(complete.next(), Some(Ok(Token::Tag("<ready>"))));
+    assert_eq!(complete.next(), None);
+
+    let mut incomplete = Token::lexer("open <in-progress").spanned();
+
+    assert_eq!(incomplete.next(), Some((Ok(Token::Text("open")), 0..4)));
+    assert_eq!(incomplete.next(), Some((Ok(Token::IncompleteTag), 5..17)));
+    assert_eq!(incomplete.next(), None);
+}
+/* ANCHOR_END: all */


### PR DESCRIPTION
## Summary

- add a handbook page for handling incomplete input with existing Logos token definitions
- add a small `partial_input` example used by the handbook
- link the page from the book summary and examples page

This is related to #554. It documents a current pattern for editor, language-server, and streaming-parser style use cases without introducing a new partial-lexing API.

## Checks

- `cargo fmt`
- `cargo run --example partial_input`
- `cargo test --example partial_input`
- `cargo check --workspace`
- `cargo clippy --workspace`
- `cargo test --workspace`
- `mdbook build book`
- `git diff --check`
