### PR TITLE
fix(source): use checked_add to prevent overflow in Source::read bounds check

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -119,7 +119,10 @@ impl Source for str {
         }
 
         #[cfg(feature = "forbid_unsafe")]
-        Chunk::from_slice(self.as_bytes().slice(offset..Chunk::SIZE + offset)?)
+        Chunk::from_slice(
+            self.as_bytes()
+                .slice(offset..offset.checked_add(Chunk::SIZE)?)?,
+        )
     }
 
     #[inline]
@@ -179,7 +182,7 @@ impl Source for [u8] {
         }
 
         #[cfg(feature = "forbid_unsafe")]
-        Chunk::from_slice(self.slice(offset..Chunk::SIZE + offset)?)
+        Chunk::from_slice(self.slice(offset..offset.checked_add(Chunk::SIZE)?)?)
     }
 
     #[inline]

--- a/src/source.rs
+++ b/src/source.rs
@@ -108,7 +108,10 @@ impl Source for str {
         Chunk: self::Chunk<'a>,
     {
         #[cfg(not(feature = "forbid_unsafe"))]
-        if offset + (Chunk::SIZE - 1) < self.len() {
+        if offset
+            .checked_add(Chunk::SIZE)
+            .map_or(false, |end| end <= self.len())
+        {
             // # Safety: we just performed a bound check.
             Some(unsafe { Chunk::from_ptr(self.as_ptr().add(offset)) })
         } else {
@@ -166,7 +169,10 @@ impl Source for [u8] {
         Chunk: self::Chunk<'a>,
     {
         #[cfg(not(feature = "forbid_unsafe"))]
-        if offset + (Chunk::SIZE - 1) < self.len() {
+        if offset
+            .checked_add(Chunk::SIZE)
+            .map_or(false, |end| end <= self.len())
+        {
             Some(unsafe { Chunk::from_ptr(self.as_ptr().add(offset)) })
         } else {
             None

--- a/src/source.rs
+++ b/src/source.rs
@@ -110,7 +110,7 @@ impl Source for str {
         #[cfg(not(feature = "forbid_unsafe"))]
         if offset
             .checked_add(Chunk::SIZE)
-            .map_or(false, |end| end <= self.len())
+            .is_some_and(|end| end <= self.len())
         {
             // # Safety: we just performed a bound check.
             Some(unsafe { Chunk::from_ptr(self.as_ptr().add(offset)) })
@@ -171,7 +171,7 @@ impl Source for [u8] {
         #[cfg(not(feature = "forbid_unsafe"))]
         if offset
             .checked_add(Chunk::SIZE)
-            .map_or(false, |end| end <= self.len())
+            .is_some_and(|end| end <= self.len())
         {
             Some(unsafe { Chunk::from_ptr(self.as_ptr().add(offset)) })
         } else {

--- a/tests/tests/old_logos_bugs.rs
+++ b/tests/tests/old_logos_bugs.rs
@@ -828,3 +828,26 @@ mod issue_461 {
         );
     }
 }
+
+// https://github.com/maciejhirsz/logos/issues/547
+// Source::read had integer overflow in the bounds check when offset is near usize::MAX,
+// which allowed the guard `offset + (Chunk::SIZE - 1) < self.len()` to evaluate to
+// true via wrapping, triggering UB in unsafe code.
+mod issue_547 {
+    use logos::Source;
+
+    #[test]
+    fn read_overflow_returns_none() {
+        let data = [0u8; 8];
+        let s: &[u8] = &data;
+        // usize::MAX wraps to 0 when added to any positive SIZE-1, so the old
+        // guard was spuriously true; the fixed guard uses checked_add and must
+        // return None here.
+        assert_eq!(<[u8] as Source>::read::<&[u8; 2]>(s, usize::MAX), None);
+        assert_eq!(<[u8] as Source>::read::<u8>(s, usize::MAX), None);
+
+        let text = "hello";
+        assert_eq!(<str as Source>::read::<&[u8; 2]>(text, usize::MAX), None);
+        assert_eq!(<str as Source>::read::<u8>(text, usize::MAX), None);
+    }
+}


### PR DESCRIPTION
Fixes #547.

The bounds check in `Source::read` for both `str` and `[u8]` used:

```rust
if offset + (Chunk::SIZE - 1) < self.len()
```

When `offset` is `usize::MAX` and `Chunk::SIZE >= 2`, the addition wraps
to 0 in release builds (or panics in debug builds). Either way the guard
is wrong: 0 < len() evaluates to true, so the unsafe `ptr.add(offset)` is
called with an invalid offset, causing undefined behavior.

Fix: replace the addition with `checked_add` so an overflowing offset
always returns `None`:

```rust
if offset
    .checked_add(Chunk::SIZE)
    .map_or(false, |end| end <= self.len())
```

The change is applied identically to both `impl Source for str` and
`impl Source for [u8]`.

A regression test is added in `tests/tests/old_logos_bugs.rs` (module
`issue_547`) that calls `Source::read` with `offset = usize::MAX` for both
source types and both `u8` and `&[u8; 2]` chunks, asserting `None` is
returned each time.