### PR TITLE
fix(tests): add derive macro to dev dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,6 +705,7 @@ version = "0.16.1"
 dependencies = [
  "ariadne",
  "chumsky",
+ "logos",
  "logos-derive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ logos-derive = {version = "0.16.1", path = "./logos-derive", optional = true}
 [dev-dependencies]
 ariadne = {version = "0.4", features = ["auto-color"]}
 chumsky = {version = "0.10.0" }
+logos = { path = ".", features = ["export_derive"] }
 
 [[example]]
 doc-scrape-examples = true  # Only needed once, because requires dev-dependencies


### PR DESCRIPTION
Noticed from #564 that some tests kept failing. Couldn't pinpoint the problematic commit.