### PR TITLE
Add morph variants that replace or map the lexer extras

### DIFF
--- a/.github/workflows/rustlib.yml
+++ b/.github/workflows/rustlib.yml
@@ -11,6 +11,7 @@ jobs:
   tests:
     name: Tests
     strategy:
+      fail-fast: false
       matrix:
         rust:
         - 1.80.0 # current MSRV

--- a/logos-codegen/src/graph/mod.rs
+++ b/logos-codegen/src/graph/mod.rs
@@ -178,7 +178,7 @@ impl fmt::Display for StateData {
         if f.alternate() {
             writeln!(f, " {{")?;
             for (bc, state) in &self.normal {
-                writeln!(f, "  {} => {}", &bc.to_string(), state)?;
+                writeln!(f, "  {bc} => {state}")?;
             }
             if let Some(eoi_state) = &self.eoi {
                 writeln!(f, "  EOI => {eoi_state}")?;

--- a/logos-codegen/src/lib.rs
+++ b/logos-codegen/src/lib.rs
@@ -354,7 +354,7 @@ pub fn generate(input: TokenStream) -> TokenStream {
                     let matching = matching
                         .iter()
                         .filter(|&id| id != leaf_id)
-                        .map(|match_id| format!("  {}", &graph.leaves()[match_id.0]))
+                        .map(|match_id| format!("  {}", graph.leaves()[match_id.0]))
                         .collect::<Vec<_>>()
                         .join("\n");
 
@@ -383,7 +383,7 @@ pub fn generate(input: TokenStream) -> TokenStream {
                 parser.err(
                     format!(
                         "The pattern {} can match the empty string, which is unsupported by logos.",
-                        &graph.leaves()[leaf_id.0],
+                        graph.leaves()[leaf_id.0],
                     ),
                     graph.leaves()[leaf_id.0].span,
                 );

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -212,6 +212,68 @@ impl<'source, Token: Logos<'source>> Lexer<'source, Token> {
         }
     }
 
+    /// Turn this lexer into a lexer for a new token type, replacing the extras
+    /// with the given value.
+    ///
+    /// Unlike [`morph`](Lexer::morph), this does not require the new extras type
+    /// to be [`From`] the current one, which is convenient when the two token
+    /// types use unrelated extras.
+    ///
+    /// The new lexer continues to point at the same span as the current lexer,
+    /// and the current token becomes the error token of the new token type.
+    pub fn morph_with_extras<Token2>(self, extras: Token2::Extras) -> Lexer<'source, Token2>
+    where
+        Token2: Logos<'source, Source = Token::Source>,
+    {
+        Lexer {
+            source: self.source,
+            is_prefix: self.is_prefix,
+            extras,
+            token_start: self.token_start,
+            token_end: self.token_end,
+        }
+    }
+
+    /// Turn this lexer into a lexer for a new token type, mapping the current
+    /// extras into the new ones with the provided closure.
+    ///
+    /// This is a more flexible variant of [`morph`](Lexer::morph) that lets you
+    /// carry state across the morph without requiring a [`From`] implementation
+    /// between the two extras types.
+    ///
+    /// The new lexer continues to point at the same span as the current lexer,
+    /// and the current token becomes the error token of the new token type.
+    pub fn morph_map_extras<Token2, F>(self, f: F) -> Lexer<'source, Token2>
+    where
+        Token2: Logos<'source, Source = Token::Source>,
+        F: FnOnce(Token::Extras) -> Token2::Extras,
+    {
+        Lexer {
+            source: self.source,
+            is_prefix: self.is_prefix,
+            extras: f(self.extras),
+            token_start: self.token_start,
+            token_end: self.token_end,
+        }
+    }
+
+    /// Turn this lexer into a lexer for a new token type, discarding the current
+    /// extras and using [`Default`] for the new ones.
+    ///
+    /// This is a convenience shorthand for
+    /// [`morph_with_extras`](Lexer::morph_with_extras) with
+    /// `Token2::Extras::default()`.
+    ///
+    /// The new lexer continues to point at the same span as the current lexer,
+    /// and the current token becomes the error token of the new token type.
+    pub fn morph_default_extras<Token2>(self) -> Lexer<'source, Token2>
+    where
+        Token2: Logos<'source, Source = Token::Source>,
+        Token2::Extras: Default,
+    {
+        self.morph_with_extras(Token2::Extras::default())
+    }
+
     /// Bumps the end of currently lexed token by `n` bytes.
     ///
     /// # Panics

--- a/tests/tests/lexer_modes.rs
+++ b/tests/tests/lexer_modes.rs
@@ -97,6 +97,66 @@ impl<'source> Iterator for ModeBridge<'source> {
     }
 }
 
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+struct CountA(usize);
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Logos)]
+#[logos(extras = CountA)]
+enum First {
+    #[token("a", |lex| lex.extras.0 += 1)]
+    A,
+    #[token("b")]
+    B,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Logos)]
+#[logos(extras = String)]
+enum Second {
+    #[token("a")]
+    A,
+    #[token("b")]
+    B,
+}
+
+#[test]
+fn morph_with_extras_replaces_extras_and_keeps_span() {
+    let mut first = First::lexer("aab");
+    assert_eq!(first.next(), Some(Ok(First::A)));
+    assert_eq!(first.next(), Some(Ok(First::A)));
+    assert_eq!(first.extras, CountA(2));
+    let start = first.span().start;
+
+    let second: Lexer<Second> = first.morph_with_extras(String::from("hello"));
+    // Span is preserved across the morph.
+    assert_eq!(second.span().start, start);
+    assert_eq!(second.extras, "hello");
+}
+
+#[test]
+fn morph_map_extras_carries_state() {
+    let mut first = First::lexer("aab");
+    assert_eq!(first.next(), Some(Ok(First::A)));
+    assert_eq!(first.next(), Some(Ok(First::A)));
+    assert_eq!(first.extras, CountA(2));
+
+    // Carry the accumulated count over into the new extras type.
+    let mut second: Lexer<Second> = first.morph_map_extras(|count| format!("saw {} a", count.0));
+    assert_eq!(second.extras, "saw 2 a");
+    assert_eq!(second.next(), Some(Ok(Second::B)));
+}
+
+#[test]
+fn morph_default_extras_resets_extras() {
+    let mut first = First::lexer("aab");
+    assert_eq!(first.next(), Some(Ok(First::A)));
+    assert_eq!(first.next(), Some(Ok(First::A)));
+    assert_eq!(first.extras, CountA(2));
+
+    // Morphing back to `First` resets the count to its default.
+    let reset: Lexer<First> = first.morph_default_extras();
+    assert_eq!(reset.extras, CountA::default());
+}
+
 #[test]
 fn iterating_modes() {
     use Inner::*;


### PR DESCRIPTION
Fixes #561.

Currently `Lexer::morph` requires `Token::Extras: Into<Token2::Extras>`, so morphing between two token types whose extras are unrelated is awkward. This adds three variants that give explicit control over the extras during a morph:

- `morph_with_extras(extras)` — morphs and replaces the extras with a supplied value.
- `morph_map_extras(f)` — morphs and maps the current extras into the new ones with a closure, letting you carry accumulated state across the morph.
- `morph_default_extras()` — morphs and resets the extras via `Default` (the `morph_default_extras` variant suggested in the issue).

All three preserve the current span (`token_start`/`token_end`), the `is_prefix` flag, and the "current token becomes the error token of the new type" semantics, matching `morph`.

Design follows the sketch in #561; `morph_default_extras` is implemented in terms of `morph_with_extras` to keep the behavior consistent.

Tests added in `tests/tests/lexer_modes.rs` cover each variant (extras replacement + span preservation, state carried through the closure, and reset-to-default), and pass under both the default and `forbid_unsafe` features.