### PR TITLE
fix(codegen): substitute subpatterns inside character classes without flag group

### DIFF
--- a/logos-codegen/src/parser/subpattern.rs
+++ b/logos-codegen/src/parser/subpattern.rs
@@ -15,7 +15,17 @@ use crate::pattern::Pattern;
 /// token regexes and other subpatterns to simplify complex expressions.
 pub struct Subpattern {
     name: Ident,
+    /// The subpattern source wrapped in its flag group, i.e. `(?u:...)`.
+    /// This is what gets substituted where a subpattern is referenced from
+    /// a regular expression context (group or top level).
     pattern: String,
+    /// The bare subpattern source without any flag wrapping. This is what gets
+    /// substituted when a subpattern is referenced from inside a character
+    /// class, where a flag-setting group like `(?u:...)` is not valid syntax and
+    /// would instead be parsed as literal characters, silently adding `u` (or
+    /// `?`, `(`, `:`) to the class and, for negated classes, excluding them.
+    /// See https://github.com/maciejhirsz/logos/issues/580.
+    bare_pattern: String,
 }
 
 impl Subpattern {
@@ -23,9 +33,12 @@ impl Subpattern {
     fn new(name: Ident, pattern_src: &Literal) -> Self {
         let pattern_str = pattern_src.escape(false);
         let flags = if pattern_src.unicode() { "u" } else { "-u" };
-        let pattern = format!("(?{flags}:{pattern_str})");
 
-        Self { name, pattern }
+        Self {
+            name,
+            pattern: format!("(?{flags}:{pattern_str})"),
+            bare_pattern: pattern_str,
+        }
     }
 }
 
@@ -70,6 +83,14 @@ impl Subpatterns {
                 continue;
             };
 
+            if let Some(subst_pattern) =
+                build.subst_bare(&subpattern.bare_pattern, pattern.span(), errors)
+            {
+                subpattern.bare_pattern = subst_pattern
+            } else {
+                continue;
+            };
+
             // Test compile the subpattern for better error messages
             // Compile w/ unicode mode, since the top level flag will set it on or off anyway
             match Pattern::compile(
@@ -108,6 +129,12 @@ impl Subpatterns {
 
     /// Given a new regex string, substitute existing subpatterns into the string.
     /// i.e. turn (?&my_subpattern) into the actual regex for "my_subpattern"
+    ///
+    /// Character-class context is tracked while scanning, so a `(?&name)`
+    /// reference inside a class gets the bare (flag-free) body — flag-setting
+    /// groups are not valid inside a class and would be parsed as literal
+    /// characters. See https://github.com/maciejhirsz/logos/issues/580.
+    ///
     /// Returns none if any non-existent subpatterns are referenced.
     pub fn subst_subpatterns(
         &self,
@@ -115,36 +142,89 @@ impl Subpatterns {
         span: Span,
         errors: &mut Errors,
     ) -> Option<String> {
-        let mut fragments = Vec::new();
+        let mut out = String::with_capacity(pattern.len());
         let mut was_error = false;
 
-        let mut current_pos = 0;
-        for group in SUBPATTERN_GROUP.find_iter(pattern) {
-            // Add the text before the match
-            if group.start() > current_pos {
-                fragments.push(&pattern[current_pos..group.start()]);
-            }
+        let bytes = pattern.as_bytes();
+        let mut i = 0usize;
+        let mut pos = 0usize; // start of the not-yet-copied literal run
+        let mut class_depth = 0usize;
 
-            // Extract the subpattern name
-            let name = &pattern[group.start() + 3..group.end() - 1]; // Skip (?& and )
+        while i < bytes.len() {
+            match bytes[i] {
+                b'\\' => {
+                    // Escape sequence: copy both bytes verbatim, no structure.
+                    i = (i + 2).min(bytes.len());
+                }
+                b'[' => {
+                    class_depth += 1;
+                    i += 1;
+                }
+                b']' => {
+                    class_depth = class_depth.saturating_sub(1);
+                    i += 1;
+                }
+                b'(' if pattern[i..].starts_with("(?&") => {
+                    // Flush the literal text before this reference.
+                    out.push_str(&pattern[pos..i]);
+                    let close = i + pattern[i..].find(')').expect("SUBPATTERN_GROUP guarantees ')'");
+                    let name = &pattern[i + 3..close];
+                    if let Some(subpattern) = self.map.get(name) {
+                        if class_depth > 0 {
+                            out.push_str(&subpattern.bare_pattern);
+                        } else {
+                            out.push_str(&subpattern.pattern);
+                        }
+                    } else {
+                        was_error = true;
+                        errors.err(format!("Subpattern `{name}` not found"), span);
+                    }
+                    i = close + 1;
+                    pos = i;
+                }
+                _ => {
+                    i += 1;
+                }
+            }
+        }
+        out.push_str(&pattern[pos..]);
+
+        if was_error {
+            None
+        } else {
+            Some(out)
+        }
+    }
+
+    /// Substitute subpatterns into a subpattern's own bare body. The result is
+    /// only ever used in class context, so all references are substituted with
+    /// their bare bodies.
+    fn subst_bare(&self, pattern: &str, span: Span, errors: &mut Errors) -> Option<String> {
+        let mut out = String::with_capacity(pattern.len());
+        let mut was_error = false;
+        let mut current_pos = 0usize;
+
+        for group in SUBPATTERN_GROUP.find_iter(pattern) {
+            if group.start() > current_pos {
+                out.push_str(&pattern[current_pos..group.start()]);
+            }
+            let name = &pattern[group.start() + 3..group.end() - 1];
             if let Some(subpattern) = self.map.get(name) {
-                fragments.push(&subpattern.pattern);
+                out.push_str(&subpattern.bare_pattern);
             } else {
                 was_error = true;
                 errors.err(format!("Subpattern `{name}` not found"), span);
             }
             current_pos = group.end();
         }
-
         if current_pos < pattern.len() {
-            // Add the remaining text after the last match
-            fragments.push(&pattern[current_pos..]);
+            out.push_str(&pattern[current_pos..]);
         }
 
         if was_error {
             None
         } else {
-            Some(fragments.join(""))
+            Some(out)
         }
     }
 }

--- a/logos-codegen/tests/codegen.rs
+++ b/logos-codegen/tests/codegen.rs
@@ -15,6 +15,7 @@ use syn::parse_file;
 #[case("explicit_lifetime0")]
 #[case("explicit_lifetime1")]
 #[case("multiple_lifetime_failure")]
+#[case("subpattern_in_class")]
 #[case("explicit_lifetime_not_found")]
 pub fn test_codegen(#[case] fixture: &str) -> Result<(), Box<dyn Error>> {
     let codegen_alg = if cfg!(feature = "state_machine_codegen") {

--- a/logos-codegen/tests/data/codegen/subpattern_in_class.rs
+++ b/logos-codegen/tests/data/codegen/subpattern_in_class.rs
@@ -1,0 +1,8 @@
+#[derive(Logos)]
+#[logos(subpattern not_unicode_letter = r"\s\d")]
+#[logos(subpattern invalid_symbols = r"#:=;\(\),\{\}\.\|")]
+#[logos(subpattern start_of_symbol = r"[^(?&not_unicode_letter)(?&invalid_symbols)]")]
+enum Token {
+    #[regex("(?&start_of_symbol)")]
+    Symbol,
+}

--- a/logos-codegen/tests/snapshots/codegen__subpattern_in_class-tailcall.snap
+++ b/logos-codegen/tests/snapshots/codegen__subpattern_in_class-tailcall.snap
@@ -1,0 +1,3761 @@
+---
+source: logos-codegen/tests/codegen.rs
+expression: formatted
+---
+#[automatically_derived]
+impl<'s> ::logos::Logos<'s> for Token {
+    type Error = ();
+    type Extras = ();
+    type Source = ::core::primitive::str;
+    fn lex(
+        lex: &mut ::logos::Lexer<'s, Self>,
+    ) -> ::core::option::Option<
+        ::core::result::Result<Self, <Self as ::logos::Logos<'s>>::Error>,
+    > {
+        use ::logos::internal::{
+            LexerInternal, CallbackRetVal, CallbackResult, SkipRetVal, SkipResult,
+        };
+        use ::core::result::Result as _Result;
+        use ::core::option::Option as _Option;
+        use ::logos::Lexer as _Lexer;
+        use ::logos::Logos;
+        macro_rules! _fast_loop {
+            ($lex:ident, $test:ident, $offset:ident) => {
+                'fast_loop : { while let _Option::Some(arr) = $lex .read:: < &
+                [::core::primitive::u8; 8usize] > ($offset) { if $test (arr[0usize]) {
+                $offset += 0usize; break 'fast_loop; } if $test (arr[1usize]) { $offset
+                += 1usize; break 'fast_loop; } if $test (arr[2usize]) { $offset +=
+                2usize; break 'fast_loop; } if $test (arr[3usize]) { $offset += 3usize;
+                break 'fast_loop; } if $test (arr[4usize]) { $offset += 4usize; break
+                'fast_loop; } if $test (arr[5usize]) { $offset += 5usize; break
+                'fast_loop; } if $test (arr[6usize]) { $offset += 6usize; break
+                'fast_loop; } if $test (arr[7usize]) { $offset += 7usize; break
+                'fast_loop; } $offset += 8usize; } while let _Option::Some(byte) = $lex
+                .read:: < ::core::primitive::u8 > ($offset) { if $test (byte) { break
+                'fast_loop; } $offset += 1; } }
+            };
+        }
+        macro_rules! _take_action {
+            ($lex:ident, $offset:ident, $context:ident, $state:ident) => {
+                { let action = _get_action($lex, $offset, $context); match action {
+                CallbackResult::Emit(tok) => { return _Option::Some(_Result::Ok(tok)); },
+                CallbackResult::Skip => { $lex .trivia(); $offset = $lex .offset();
+                $context = _Option::None; return state0($lex, $offset, $context); },
+                CallbackResult::Error(err) => { return _Option::Some(_Result::Err(err));
+                }, CallbackResult::DefaultError => { return
+                _Option::Some(_Result::Err(_make_error($lex))); }, } }
+            };
+        }
+        const _TABLE_0: [::core::primitive::u8; 256] = [
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 255u8, 255u8, 255u8, 255u8, 255u8,
+            254u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8,
+            255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8,
+            255u8, 255u8, 255u8, 255u8, 223u8, 252u8, 253u8, 253u8, 253u8, 253u8, 253u8,
+            253u8, 253u8, 253u8, 253u8, 255u8, 255u8, 255u8, 255u8, 255u8, 191u8, 251u8,
+            123u8, 123u8, 107u8, 123u8, 123u8, 123u8, 123u8, 123u8, 123u8, 127u8, 255u8,
+            247u8, 255u8, 255u8, 255u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+        ];
+        const _TABLE_1: [::core::primitive::u8; 256] = [
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 43u8, 43u8, 43u8, 43u8, 43u8, 43u8,
+            11u8, 11u8, 11u8, 11u8, 79u8, 95u8, 95u8, 95u8, 95u8, 95u8, 50u8, 50u8, 50u8,
+            50u8, 50u8, 50u8, 50u8, 50u8, 50u8, 50u8, 123u8, 123u8, 123u8, 123u8, 123u8,
+            123u8, 123u8, 123u8, 123u8, 123u8, 127u8, 127u8, 125u8, 125u8, 109u8, 109u8,
+            125u8, 125u8, 125u8, 125u8, 125u8, 109u8, 119u8, 119u8, 119u8, 119u8, 119u8,
+            119u8, 119u8, 119u8, 119u8, 119u8, 127u8, 127u8, 127u8, 127u8, 127u8, 127u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+            0u8, 0u8, 0u8, 0u8,
+        ];
+        #[inline]
+        fn _make_error<'s>(lex: &mut _Lexer<'s, Token>) -> <Token as Logos<'s>>::Error {
+            <<Token as Logos<'s>>::Error as ::core::default::Default>::default()
+        }
+        #[inline]
+        fn _get_action<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            offset: ::core::primitive::usize,
+            context: _Option<LogosLeaf>,
+        ) -> CallbackResult<'s, Token> {
+            match context {
+                _Option::None => {
+                    lex.end_to_boundary(offset.max(lex.offset() + 1));
+                    CallbackResult::Error(_make_error(lex))
+                }
+                _Option::Some(LogosLeaf::Leaf0) => CallbackResult::Emit(Token::Symbol),
+            }
+        }
+        #[derive(::core::clone::Clone, ::core::marker::Copy)]
+        enum LogosLeaf {
+            Leaf0 = 0isize,
+        }
+        fn state0<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                #[derive(::core::marker::Copy, ::core::clone::Clone)]
+                enum LogosNextState {
+                    ___,
+                    State1,
+                    State2,
+                    State3,
+                    State4,
+                    State5,
+                    State6,
+                    State7,
+                    State8,
+                    State9,
+                    State10,
+                    State11,
+                    State12,
+                    State13,
+                    State14,
+                    State15,
+                    State16,
+                    State36,
+                }
+                const TABLE: [LogosNextState; 256] = {
+                    use LogosNextState::*;
+                    [
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        ___,
+                        State36,
+                        State36,
+                        ___,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        ___,
+                        ___,
+                        State36,
+                        State36,
+                        ___,
+                        State36,
+                        ___,
+                        State36,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        State36,
+                        ___,
+                        State36,
+                        ___,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        ___,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        State36,
+                        ___,
+                        ___,
+                        ___,
+                        State36,
+                        State36,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        State1,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State3,
+                        State2,
+                        State4,
+                        State2,
+                        State2,
+                        State2,
+                        State5,
+                        State6,
+                        State7,
+                        State8,
+                        State9,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State11,
+                        State10,
+                        State10,
+                        State12,
+                        State10,
+                        State13,
+                        State14,
+                        State15,
+                        State15,
+                        State15,
+                        State16,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                    ]
+                };
+                offset += 1;
+                match TABLE[byte as ::core::primitive::usize] {
+                    LogosNextState::State1 => {
+                        return state1(lex, offset, context);
+                    }
+                    LogosNextState::State2 => {
+                        return state2(lex, offset, context);
+                    }
+                    LogosNextState::State3 => {
+                        return state3(lex, offset, context);
+                    }
+                    LogosNextState::State4 => {
+                        return state4(lex, offset, context);
+                    }
+                    LogosNextState::State5 => {
+                        return state5(lex, offset, context);
+                    }
+                    LogosNextState::State6 => {
+                        return state6(lex, offset, context);
+                    }
+                    LogosNextState::State7 => {
+                        return state7(lex, offset, context);
+                    }
+                    LogosNextState::State8 => {
+                        return state8(lex, offset, context);
+                    }
+                    LogosNextState::State9 => {
+                        return state9(lex, offset, context);
+                    }
+                    LogosNextState::State10 => {
+                        return state10(lex, offset, context);
+                    }
+                    LogosNextState::State11 => {
+                        return state11(lex, offset, context);
+                    }
+                    LogosNextState::State12 => {
+                        return state12(lex, offset, context);
+                    }
+                    LogosNextState::State13 => {
+                        return state13(lex, offset, context);
+                    }
+                    LogosNextState::State14 => {
+                        return state14(lex, offset, context);
+                    }
+                    LogosNextState::State15 => {
+                        return state15(lex, offset, context);
+                    }
+                    LogosNextState::State16 => {
+                        return state16(lex, offset, context);
+                    }
+                    LogosNextState::State36 => {
+                        return state36(lex, offset, context);
+                    }
+                    LogosNextState::___ => {}
+                }
+                offset -= 1;
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+                if lex.offset() == offset {
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state1<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_0[byte as ::core::primitive::usize] & 1u8 != 0 {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state2<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if (::core::matches!(byte, 128u8..= 191u8)) {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state3<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_0[byte as ::core::primitive::usize] & 2u8 != 0 {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state4<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_0[byte as ::core::primitive::usize] & 4u8 != 0 {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state5<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if (::core::matches!(byte, 138u8..= 191u8)) {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state6<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                #[derive(::core::marker::Copy, ::core::clone::Clone)]
+                enum LogosNextState {
+                    ___,
+                    State2,
+                    State3,
+                    State25,
+                    State27,
+                }
+                const TABLE: [LogosNextState; 256] = {
+                    use LogosNextState::*;
+                    [
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State27,
+                        State2,
+                        State27,
+                        State2,
+                        State27,
+                        State2,
+                        State27,
+                        State2,
+                        State27,
+                        State2,
+                        State27,
+                        State2,
+                        State27,
+                        State2,
+                        State27,
+                        State2,
+                        State27,
+                        State2,
+                        State27,
+                        State2,
+                        State25,
+                        State2,
+                        State25,
+                        State3,
+                        State2,
+                        State2,
+                        State2,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                    ]
+                };
+                offset += 1;
+                match TABLE[byte as ::core::primitive::usize] {
+                    LogosNextState::State2 => {
+                        return state2(lex, offset, context);
+                    }
+                    LogosNextState::State3 => {
+                        return state3(lex, offset, context);
+                    }
+                    LogosNextState::State25 => {
+                        return state25(lex, offset, context);
+                    }
+                    LogosNextState::State27 => {
+                        return state27(lex, offset, context);
+                    }
+                    LogosNextState::___ => {}
+                }
+                offset -= 1;
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state7<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                #[derive(::core::marker::Copy, ::core::clone::Clone)]
+                enum LogosNextState {
+                    ___,
+                    State2,
+                    State3,
+                    State4,
+                    State5,
+                    State25,
+                    State31,
+                    State34,
+                    State35,
+                }
+                const TABLE: [LogosNextState; 256] = {
+                    use LogosNextState::*;
+                    [
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        State2,
+                        State5,
+                        State25,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State31,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State3,
+                        State25,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State34,
+                        State2,
+                        State25,
+                        State2,
+                        State2,
+                        State35,
+                        State2,
+                        State2,
+                        State25,
+                        State4,
+                        State2,
+                        State2,
+                        State35,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                    ]
+                };
+                offset += 1;
+                match TABLE[byte as ::core::primitive::usize] {
+                    LogosNextState::State2 => {
+                        return state2(lex, offset, context);
+                    }
+                    LogosNextState::State3 => {
+                        return state3(lex, offset, context);
+                    }
+                    LogosNextState::State4 => {
+                        return state4(lex, offset, context);
+                    }
+                    LogosNextState::State5 => {
+                        return state5(lex, offset, context);
+                    }
+                    LogosNextState::State25 => {
+                        return state25(lex, offset, context);
+                    }
+                    LogosNextState::State31 => {
+                        return state31(lex, offset, context);
+                    }
+                    LogosNextState::State34 => {
+                        return state34(lex, offset, context);
+                    }
+                    LogosNextState::State35 => {
+                        return state35(lex, offset, context);
+                    }
+                    LogosNextState::___ => {}
+                }
+                offset -= 1;
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state8<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                #[derive(::core::marker::Copy, ::core::clone::Clone)]
+                enum LogosNextState {
+                    ___,
+                    State2,
+                    State32,
+                    State33,
+                }
+                const TABLE: [LogosNextState; 256] = {
+                    use LogosNextState::*;
+                    [
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        State32,
+                        State33,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                    ]
+                };
+                offset += 1;
+                match TABLE[byte as ::core::primitive::usize] {
+                    LogosNextState::State2 => {
+                        return state2(lex, offset, context);
+                    }
+                    LogosNextState::State32 => {
+                        return state32(lex, offset, context);
+                    }
+                    LogosNextState::State33 => {
+                        return state33(lex, offset, context);
+                    }
+                    LogosNextState::___ => {}
+                }
+                offset -= 1;
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state9<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if (::core::matches!(byte, 129u8..= 191u8)) {
+                    offset += 1;
+                    return state2(lex, offset, context);
+                }
+                if (byte == 128u8) {
+                    offset += 1;
+                    return state31(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state10<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if (::core::matches!(byte, 128u8..= 191u8)) {
+                    offset += 1;
+                    return state2(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state11<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                #[derive(::core::marker::Copy, ::core::clone::Clone)]
+                enum LogosNextState {
+                    ___,
+                    State2,
+                    State3,
+                    State4,
+                    State5,
+                    State25,
+                    State30,
+                }
+                const TABLE: [LogosNextState; 256] = {
+                    use LogosNextState::*;
+                    [
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State3,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State25,
+                        State5,
+                        State2,
+                        State2,
+                        State30,
+                        State2,
+                        State25,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State4,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                    ]
+                };
+                offset += 1;
+                match TABLE[byte as ::core::primitive::usize] {
+                    LogosNextState::State2 => {
+                        return state2(lex, offset, context);
+                    }
+                    LogosNextState::State3 => {
+                        return state3(lex, offset, context);
+                    }
+                    LogosNextState::State4 => {
+                        return state4(lex, offset, context);
+                    }
+                    LogosNextState::State5 => {
+                        return state5(lex, offset, context);
+                    }
+                    LogosNextState::State25 => {
+                        return state25(lex, offset, context);
+                    }
+                    LogosNextState::State30 => {
+                        return state30(lex, offset, context);
+                    }
+                    LogosNextState::___ => {}
+                }
+                offset -= 1;
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state12<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if (::core::matches!(byte, 128u8..= 159u8)) {
+                    offset += 1;
+                    return state2(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state13<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_0[byte as ::core::primitive::usize] & 8u8 != 0 {
+                    offset += 1;
+                    return state2(lex, offset, context);
+                }
+                if (byte == 188u8) {
+                    offset += 1;
+                    return state25(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state14<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                #[derive(::core::marker::Copy, ::core::clone::Clone)]
+                enum LogosNextState {
+                    ___,
+                    State10,
+                    State17,
+                    State18,
+                    State19,
+                    State20,
+                    State21,
+                    State22,
+                    State23,
+                }
+                const TABLE: [LogosNextState; 256] = {
+                    use LogosNextState::*;
+                    [
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        State17,
+                        State18,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State19,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State20,
+                        State21,
+                        State22,
+                        State23,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        State10,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                    ]
+                };
+                offset += 1;
+                match TABLE[byte as ::core::primitive::usize] {
+                    LogosNextState::State10 => {
+                        return state10(lex, offset, context);
+                    }
+                    LogosNextState::State17 => {
+                        return state17(lex, offset, context);
+                    }
+                    LogosNextState::State18 => {
+                        return state18(lex, offset, context);
+                    }
+                    LogosNextState::State19 => {
+                        return state19(lex, offset, context);
+                    }
+                    LogosNextState::State20 => {
+                        return state20(lex, offset, context);
+                    }
+                    LogosNextState::State21 => {
+                        return state21(lex, offset, context);
+                    }
+                    LogosNextState::State22 => {
+                        return state22(lex, offset, context);
+                    }
+                    LogosNextState::State23 => {
+                        return state23(lex, offset, context);
+                    }
+                    LogosNextState::___ => {}
+                }
+                offset -= 1;
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state15<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if (::core::matches!(byte, 128u8..= 191u8)) {
+                    offset += 1;
+                    return state10(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state16<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if (::core::matches!(byte, 128u8..= 143u8)) {
+                    offset += 1;
+                    return state10(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state17<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                #[derive(::core::marker::Copy, ::core::clone::Clone)]
+                enum LogosNextState {
+                    ___,
+                    State2,
+                    State3,
+                    State4,
+                    State5,
+                }
+                const TABLE: [LogosNextState; 256] = {
+                    use LogosNextState::*;
+                    [
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State3,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State4,
+                        State5,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                    ]
+                };
+                offset += 1;
+                match TABLE[byte as ::core::primitive::usize] {
+                    LogosNextState::State2 => {
+                        return state2(lex, offset, context);
+                    }
+                    LogosNextState::State3 => {
+                        return state3(lex, offset, context);
+                    }
+                    LogosNextState::State4 => {
+                        return state4(lex, offset, context);
+                    }
+                    LogosNextState::State5 => {
+                        return state5(lex, offset, context);
+                    }
+                    LogosNextState::___ => {}
+                }
+                offset -= 1;
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state18<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                #[derive(::core::marker::Copy, ::core::clone::Clone)]
+                enum LogosNextState {
+                    ___,
+                    State2,
+                    State3,
+                    State4,
+                    State25,
+                    State27,
+                    State28,
+                    State29,
+                }
+                const TABLE: [LogosNextState; 256] = {
+                    use LogosNextState::*;
+                    [
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        State2,
+                        State27,
+                        State2,
+                        State4,
+                        State28,
+                        State2,
+                        State2,
+                        State25,
+                        State2,
+                        State2,
+                        State2,
+                        State4,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State25,
+                        State2,
+                        State25,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State25,
+                        State2,
+                        State29,
+                        State4,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State3,
+                        State2,
+                        State25,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State4,
+                        State2,
+                        State25,
+                        State2,
+                        State2,
+                        State2,
+                        State25,
+                        State3,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State25,
+                        State2,
+                        State2,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                    ]
+                };
+                offset += 1;
+                match TABLE[byte as ::core::primitive::usize] {
+                    LogosNextState::State2 => {
+                        return state2(lex, offset, context);
+                    }
+                    LogosNextState::State3 => {
+                        return state3(lex, offset, context);
+                    }
+                    LogosNextState::State4 => {
+                        return state4(lex, offset, context);
+                    }
+                    LogosNextState::State25 => {
+                        return state25(lex, offset, context);
+                    }
+                    LogosNextState::State27 => {
+                        return state27(lex, offset, context);
+                    }
+                    LogosNextState::State28 => {
+                        return state28(lex, offset, context);
+                    }
+                    LogosNextState::State29 => {
+                        return state29(lex, offset, context);
+                    }
+                    LogosNextState::___ => {}
+                }
+                offset -= 1;
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state19<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                #[derive(::core::marker::Copy, ::core::clone::Clone)]
+                enum LogosNextState {
+                    ___,
+                    State2,
+                    State3,
+                    State4,
+                    State5,
+                    State25,
+                }
+                const TABLE: [LogosNextState; 256] = {
+                    use LogosNextState::*;
+                    [
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State4,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State3,
+                        State2,
+                        State5,
+                        State2,
+                        State25,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State4,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                    ]
+                };
+                offset += 1;
+                match TABLE[byte as ::core::primitive::usize] {
+                    LogosNextState::State2 => {
+                        return state2(lex, offset, context);
+                    }
+                    LogosNextState::State3 => {
+                        return state3(lex, offset, context);
+                    }
+                    LogosNextState::State4 => {
+                        return state4(lex, offset, context);
+                    }
+                    LogosNextState::State5 => {
+                        return state5(lex, offset, context);
+                    }
+                    LogosNextState::State25 => {
+                        return state25(lex, offset, context);
+                    }
+                    LogosNextState::___ => {}
+                }
+                offset -= 1;
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state20<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_0[byte as ::core::primitive::usize] & 16u8 != 0 {
+                    offset += 1;
+                    return state2(lex, offset, context);
+                }
+                if (byte == 179u8) {
+                    offset += 1;
+                    return state4(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state21<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_0[byte as ::core::primitive::usize] & 32u8 != 0 {
+                    offset += 1;
+                    return state2(lex, offset, context);
+                }
+                if (byte == 159u8) {
+                    offset += 1;
+                    return state26(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state22<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                #[derive(::core::marker::Copy, ::core::clone::Clone)]
+                enum LogosNextState {
+                    ___,
+                    State2,
+                    State4,
+                    State5,
+                    State24,
+                    State25,
+                }
+                const TABLE: [LogosNextState; 256] = {
+                    use LogosNextState::*;
+                    [
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State5,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State4,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State4,
+                        State2,
+                        State2,
+                        State2,
+                        State24,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State25,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        State2,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                        ___,
+                    ]
+                };
+                offset += 1;
+                match TABLE[byte as ::core::primitive::usize] {
+                    LogosNextState::State2 => {
+                        return state2(lex, offset, context);
+                    }
+                    LogosNextState::State4 => {
+                        return state4(lex, offset, context);
+                    }
+                    LogosNextState::State5 => {
+                        return state5(lex, offset, context);
+                    }
+                    LogosNextState::State24 => {
+                        return state24(lex, offset, context);
+                    }
+                    LogosNextState::State25 => {
+                        return state25(lex, offset, context);
+                    }
+                    LogosNextState::___ => {}
+                }
+                offset -= 1;
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state23<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_0[byte as ::core::primitive::usize] & 64u8 != 0 {
+                    offset += 1;
+                    return state2(lex, offset, context);
+                }
+                if (byte == 175u8) {
+                    offset += 1;
+                    return state4(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state24<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_0[byte as ::core::primitive::usize] & 128u8 != 0 {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state25<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_1[byte as ::core::primitive::usize] & 1u8 != 0 {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state26<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if (::core::matches!(byte, 128u8..= 141u8)) {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state27<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_1[byte as ::core::primitive::usize] & 2u8 != 0 {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state28<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if (::core::matches!(byte, 128u8..= 181u8)) {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state29<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_1[byte as ::core::primitive::usize] & 4u8 != 0 {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state30<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_1[byte as ::core::primitive::usize] & 8u8 != 0 {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state31<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if (::core::matches!(byte, 129u8..= 191u8)) {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state32<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_1[byte as ::core::primitive::usize] & 16u8 != 0 {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state33<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_0[byte as ::core::primitive::usize] & 32u8 != 0 {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state34<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_1[byte as ::core::primitive::usize] & 32u8 != 0 {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state35<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {
+                if _TABLE_1[byte as ::core::primitive::usize] & 64u8 != 0 {
+                    offset += 1;
+                    return state36(lex, offset, context);
+                }
+            } else {
+                if lex.is_prefix() {
+                    lex.end(lex.offset());
+                    return _Option::None;
+                }
+            }
+            _take_action!(lex, offset, context, state)
+        }
+        fn state36<'s>(
+            lex: &mut _Lexer<'s, Token>,
+            mut offset: ::core::primitive::usize,
+            mut context: _Option<LogosLeaf>,
+        ) -> _Option<_Result<Token, <Token as Logos<'s>>::Error>> {
+            lex.end(offset);
+            context = _Option::Some(LogosLeaf::Leaf0);
+            let other = lex.read::<::core::primitive::u8>(offset);
+            if let _Option::Some(byte) = other {} else {}
+            _take_action!(lex, offset, context, state)
+        }
+        state0(lex, lex.offset(), _Option::None)
+    }
+}

--- a/tests/tests/advanced.rs
+++ b/tests/tests/advanced.rs
@@ -242,4 +242,38 @@ mod advanced {
             ],
         );
     }
+
+    #[test]
+    fn subpattern_inside_character_class() {
+        // https://github.com/maciejhirsz/logos/issues/580
+        //
+        // A subpattern referenced inside a character class used to be
+        // substituted with its flag-wrapped body, i.e. `(?u:...)`. Flag-setting
+        // groups are not valid inside a class, so the regex parser treated the
+        // characters literally: `u` (and `?`, `(`, `:`) became class members,
+        // and a negated class would then exclude them. This broke matching of
+        // the letter `u` and nothing else.
+        assert_lex(
+            "u a U w _ ; 0",
+            &[
+                (Ok(Token580::LetterOrUnderscore), "u", 0..1),
+                (Ok(Token580::LetterOrUnderscore), "a", 2..3),
+                (Ok(Token580::LetterOrUnderscore), "U", 4..5),
+                (Ok(Token580::LetterOrUnderscore), "w", 6..7),
+                (Ok(Token580::LetterOrUnderscore), "_", 8..9),
+                (Err(()), ";", 10..11),
+                (Err(()), "0", 12..13),
+            ],
+        );
+    }
+}
+
+#[derive(Logos, Debug, Clone, Copy, PartialEq)]
+#[logos(subpattern not_unicode_letter = r"\s\d")]
+#[logos(subpattern invalid_symbols = r"#:=;\(\),\{\}\.\|")]
+#[logos(subpattern start_of_symbol = r"[^(?&not_unicode_letter)(?&invalid_symbols)]")]
+#[logos(skip r"\s+")]
+enum Token580 {
+    #[regex("(?&start_of_symbol)")]
+    LetterOrUnderscore,
 }


### PR DESCRIPTION
## Summary

Fixes #580.

A subpattern referenced inside a character class was substituted with its flag-wrapped body, i.e. `(?u:...)`:

```rust
#[logos(subpattern start_of_symbol = r"[^(?&not_unicode_letter)(?&invalid_symbols)]")]
```

After substitution this became `[^ (?u:\s\d) (?u:#:=;...) ]`. Flag-setting groups are **not valid regex syntax inside a character class**, so `regex-syntax` parses those characters literally: `u` (as well as `?`, `(`, `:`) silently become class members — and a negated class then *excludes* them. Concretely, tokens built from such a class failed to lex the letter `u` and nothing else, which matches the report in #580 exactly (`MISMATCH on 'u'`).

## Fix

`Subpatterns::subst_subpatterns` now tracks character-class context while scanning the pattern (honoring `\` escapes and nested `[`/`]`):

- **inside a class** — the subpattern is substituted with its **bare** (flag-free) body;
- **outside a class** — the flag-wrapped body is used, exactly as before.

The per-subpattern test compile in `Subpatterns::new` still uses the wrapped form, so all existing error diagnostics (invalid regex, UTF-8 mode, etc.) are unchanged. Nested subpattern definitions resolve their bare bodies with the same class-aware logic.

## Testing

- Added a regression test `subpattern_inside_character_class` in `tests/tests/advanced.rs` lexing `u a U w _ ; 0` — before the fix `u` produced `Err(())` while `a`, `U`, `w`, `_` matched.
- Added a codegen snapshot fixture `subpattern_in_class.rs` capturing the generated tables.
- Full workspace test suite passes (`cargo test --workspace`): unit tests, integration tests, codegen snapshots, and UI tests.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>